### PR TITLE
DOC: LICENSE now mentioned in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ repos using our CLA.
 This project has adopted the Microsoft Open Source Code of Conduct. For more information see the Code of Conduct FAQ or contact 
 opencode@microsoft.com with any additional questions or comments.
 
+## License
+LLVM is licensed under the [LLVM Release License](https://github.com/Microsoft/llvm-mctoll/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ This project has adopted the Microsoft Open Source Code of Conduct. For more inf
 opencode@microsoft.com with any additional questions or comments.
 
 ## License
-LLVM is licensed under the [LLVM Release License](https://github.com/Microsoft/llvm-mctoll/blob/master/LICENSE)
+LLVM-mctoll is licensed under the [LLVM Release License](https://github.com/Microsoft/llvm-mctoll/blob/master/LICENSE)


### PR DESCRIPTION
Added subsection for License in README.md
Fixes Issue [#5](https://github.com/Microsoft/llvm-mctoll/issues/5)