### PR TITLE
Fix for latest llvm.

### DIFF
--- a/ExternalFunctions.cpp
+++ b/ExternalFunctions.cpp
@@ -81,7 +81,7 @@ Function *ExternalFunctions::Create(StringRef &CFuncName, Module &module) {
       assert(false &&
              "Failed to construct function type for external function");
     }
-    Constant *FC = module.getOrInsertFunction(CFuncName, FuncType);
+    Value* FC = module.getOrInsertFunction(CFuncName, FuncType).getCallee();
     assert(isa<Function>(FC) && "Expect Function");
 
     Func = reinterpret_cast<Function *>(FC);


### PR DESCRIPTION
This is a single line fix to get llvm-mctoll to build on the latest LLVM tree.