### PR TITLE
[X86-64] Add support for CALL64m instruction

### DIFF
--- a/X86/X86AdditionalInstrInfo.cpp
+++ b/X86/X86AdditionalInstrInfo.cpp
@@ -388,7 +388,7 @@ static constexpr const_addl_instr_info::value_type mapdata[] = {
     {X86::CALL32m_NT, {0, Unknown}},
     {X86::CALL32r, {0, Unknown}},
     {X86::CALL32r_NT, {0, Unknown}},
-    {X86::CALL64m, {0, Unknown}},
+    {X86::CALL64m, {8, Unknown}},
     {X86::CALL64m_NT, {0, Unknown}},
     {X86::CALL64pcrel32, {0, Unknown}},
     {X86::CALL64r, {0, Unknown}},

--- a/X86/X86FuncPrototypeDiscovery.cpp
+++ b/X86/X86FuncPrototypeDiscovery.cpp
@@ -401,7 +401,7 @@ FunctionType *X86MachineInstructionRaiser::getRaisedFunctionPrototype() {
                 MBBDefRegs[find64BitSuperReg(RetReg)] = RetRegSizeInBits / 8;
               }
             }
-          } else if (Opcode != X86::CALL64r) {
+          } else if (Opcode != X86::CALL64r && Opcode != X86::CALL64m) {
             // Not possible to statically determine the target of register-based
             // indirect call. Need to handle differently.
             assert(false && "Unhandled call or branch found");

--- a/X86/X86MachineInstructionRaiser.h
+++ b/X86/X86MachineInstructionRaiser.h
@@ -144,6 +144,8 @@ private:
   bool raiseDirectBranchMachineInstr(ControlTransferInfo *);
   bool raiseIndirectBranchMachineInstr(ControlTransferInfo *);
 
+  Value *getMemoryRefValue(const MachineInstr &);
+
   // Helper functions
   // Cleanup MachineBasicBlocks
   static bool deleteNOOPInstrMI(MachineBasicBlock &,

--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -24,9 +24,146 @@
 #include <X86Subtarget.h>
 #include <iterator>
 
+#define DEBUG_TYPE "mctoll"
+
 using namespace llvm;
 using namespace mctoll;
 using namespace X86RegisterUtils;
+
+Value *X86MachineInstructionRaiser::getMemoryRefValue(const MachineInstr &MI) {
+  const MCInstrDesc &MIDesc = MI.getDesc();
+  unsigned int Opcode = MI.getOpcode();
+
+  int LoadOrStoreOpIndex = -1;
+
+  // Get index of memory reference in the instruction.
+  int MemoryRefOpIndex = getMemoryRefOpIndex(MI);
+  // Should have found the index of the memory reference operand
+  assert(MemoryRefOpIndex != -1 && "Unable to find memory reference "
+                                   "operand of a load/store instruction");
+  X86AddressMode MemRef = llvm::getAddressFromInstr(&MI, MemoryRefOpIndex);
+
+  // Get the operand whose value is stored to memory or that is loaded from
+  // memory.
+
+  if (MIDesc.mayStore()) {
+    // If the instruction stores to stack, find the register whose value is
+    // being stored. It would be the operand at offset
+    // memRefOperandStartIndex + X86::AddrNumOperands
+    LoadOrStoreOpIndex = MemoryRefOpIndex + X86::AddrNumOperands;
+  } else if (MIDesc.mayLoad()) {
+    // If the instruction loads to memory to a register, it has 1 def.
+    // Operand 0 is the loadOrStoreOp.
+    assert(((MIDesc.getNumDefs() == 0) || (MIDesc.getNumDefs() == 1)) &&
+           "Instruction that loads from memory expected to have only "
+           "one target");
+    if (MIDesc.getNumDefs() == 1) {
+      LoadOrStoreOpIndex = 0;
+      assert(MI.getOperand(LoadOrStoreOpIndex).isReg() &&
+             "Target of instruction that loads from "
+             "memory expected to be a register");
+    } else if (!MIDesc.isCompare() && !MIDesc.isCall()) {
+      switch (getInstructionKind(Opcode)) {
+      case InstructionKind::DIVIDE_MEM_OP:
+      case InstructionKind::LOAD_FPU_REG:
+        break;
+      default:
+        MI.print(errs());
+        assert(false && "Encountered unhandled memory load instruction");
+      }
+    }
+  } else {
+    MI.print(errs());
+    assert(false && "Encountered unhandled instruction that is not load/store");
+  }
+
+  Value *MemoryRefValue = nullptr;
+
+  if (MemRef.BaseType == X86AddressMode::RegBase) {
+    // If it is a stack reference, allocate a stack slot in case the current
+    // memory reference is new. Else get the stack reference using the
+    // stackslot index of the previously known stack ref.
+
+    uint64_t BaseSupReg = find64BitSuperReg(MemRef.Base.Reg);
+    if (BaseSupReg == x86RegisterInfo->getStackRegister() ||
+        BaseSupReg == x86RegisterInfo->getFramePtr()) {
+      MemoryRefValue = getStackAllocatedValue(MI, MemRef, false);
+
+      // If memory operand has an index register with possibly a non-zero scale
+      // value, add the value represented by IndexReg*Scale to MemoryRefValue.
+      if (MemRef.IndexReg != X86::NoRegister) {
+        assert((MemoryRefValue != nullptr) &&
+               "Unexpected null value of stack or base pointer register");
+        Type *MemRefValTy = MemoryRefValue->getType();
+        assert((MemRefValTy->isPointerTy()) &&
+               "Unexpected non-pointer type of a stack allocated value");
+        // Convert MemRefValue to integer
+        LLVMContext &Ctx(MF.getFunction().getContext());
+        Type *CastTy = Type::getInt64Ty(Ctx);
+        BasicBlock *RaisedBB = getRaisedBasicBlock(MI.getParent());
+        PtrToIntInst *MemRefValAddr =
+            new PtrToIntInst(MemoryRefValue, CastTy, "", RaisedBB);
+
+        unsigned ScaleAmt = MemRef.Scale;
+        // IndexReg * Scale
+        Value *IndexVal = getPhysRegValue(MI, MemRef.IndexReg);
+        // Cast IndexRegVal as 64-bit integer, if needed.
+        IndexVal = getRaisedValues()->castValue(IndexVal, CastTy, RaisedBB);
+
+        // Generate mul instruction based on Scale value
+        switch (ScaleAmt) {
+        case 0:
+          assert(false && "Unexpected zero-value of scale in memory operand");
+          break;
+        case 1:
+          break;
+        default: {
+          Value *ScaleAmtValue = ConstantInt::get(CastTy, ScaleAmt);
+          Instruction *MulInst = BinaryOperator::CreateMul(
+              ScaleAmtValue, IndexVal, "sc-m", RaisedBB);
+          IndexVal = MulInst;
+        } break;
+        }
+
+        // MemoryRefValue + IndexReg*Scale
+        Instruction *AddInst = BinaryOperator::CreateAdd(
+            MemRefValAddr, IndexVal, "idx-a", RaisedBB);
+        // Propagate any rodata related metadata
+        getRaisedValues()->setInstMetadataRODataIndex(MemoryRefValue, AddInst);
+        // Cast the computed address back to MemRefValTy
+        MemoryRefValue =
+            getRaisedValues()->castValue(AddInst, MemRefValTy, RaisedBB);
+      }
+    }
+      // Handle PC-relative addressing.
+
+      // NOTE: This tool now raises only shared libraries and executables -
+      // NOT object files. So, instructions with 0 register (which typically
+      // are seen in a relocatable object file for the linker to patch) are
+      // not expected to be encountered.
+    else if (BaseSupReg == X86::RIP) {
+      MemoryRefValue = createPCRelativeAccesssValue(MI);
+    }
+
+    // If this is neither a stack reference nor a pc-relative access, get the
+    // associated memory address expression value.
+    if (MemoryRefValue == nullptr) {
+      Value *memrefValue = getMemoryAddressExprValue(MI);
+      MemoryRefValue = memrefValue;
+    }
+  } else {
+    // TODO : Memory references with BaseType FrameIndexBase
+    // (i.e., not RegBase type)
+    outs() << "****** Unhandled memory reference in instruction\n\t";
+    LLVM_DEBUG(MI.dump());
+    outs() << "****** reference of type FrameIndexBase";
+  }
+
+  assert(MemoryRefValue != nullptr &&
+         "Unable to construct memory referencing value");
+
+  return MemoryRefValue;
+}
 
 // Delete noop instructions
 bool X86MachineInstructionRaiser::deleteNOOPInstrMI(
@@ -2150,3 +2287,5 @@ bool X86MachineInstructionRaiser::instrNameStartsWith(const MachineInstr &MI,
                                                       StringRef name) const {
   return x86InstrInfo->getName(MI.getOpcode()).startswith(name);
 }
+
+#undef DEBUG_TYPE

--- a/test/asm_test/X86/raise-call64m.s
+++ b/test/asm_test/X86/raise-call64m.s
@@ -1,0 +1,47 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: Called function
+// CHECK: Returned from function
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "raise-call64m.s"
+
+.p2align    4, 0x90
+.type    func1,@function
+func1:
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+    ret
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    mov rax, OFFSET func1
+    sub rsp, 8
+    mov [rsp], rax
+    call [rsp]
+    movabs rdi, offset .L.str.1
+    mov al, 0
+    call printf
+    xor rax, rax
+    add rsp, 8
+    ret
+
+
+    .type   .L.str,@object                  # @.str
+    .section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "Called function\n"
+    .size   .L.str, 17
+
+    .type   .L.str.1,@object                # @.str.1
+.L.str.1:
+    .asciz  "Returned from function\n"
+    .size   .L.str.1, 24

--- a/test/smoke_test/call-function-pointer.c
+++ b/test/smoke_test/call-function-pointer.c
@@ -1,0 +1,29 @@
+// REQUIRES: system-linux
+// RUN: clang -O0 -o %t %s -O2
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: Called function 1
+// CHECK: Called function 2
+// CHECK: Called function 3
+// CHECK-EMPTY
+
+#include <stdio.h>
+
+void func(int i) {
+  printf("Called function %d\n", i);
+}
+
+int main() {
+  void (*functions[3]) (int);
+
+  for (int i = 0; i < 3; ++i) {
+    functions[i] = func;
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    functions[i](i + 1);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This adds support for indirect calls from memory locations
Example:

```s
call [rsp]
```

I have moved some functionality from `raiseMemRefMachineInstr` into it's own function `X86MachineInstructionRaiser::getMemoryRefValue`, since that functionality is needed to load the memory value stored in `CALL64m`'s operand.

