### PR TITLE
 [x86-64] Fixed issues with memory operations on global variables

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -1317,38 +1317,21 @@ bool X86MachineInstructionRaiser::raiseBinaryOpMemToRegInstr(
           isa<GlobalValue>(MemRefValue) ||
           MemRefValue->getType()->isPointerTy()) &&
          "Unexpected type of memory reference in binary mem op instruction");
-  bool IsMemRefGlobalVal = false;
   // If it is an effective address
   if (isEffectiveAddrValue(MemRefValue)) {
-    // Check if this is a load if a global value
-    if (isa<LoadInst>(MemRefValue)) {
-      LoadInst *LdInst = dyn_cast<LoadInst>(MemRefValue);
-      if (isa<GlobalValue>(LdInst->getPointerOperand())) {
-        IsMemRefGlobalVal = true;
-      }
-    } else {
-      // This is an effective address computation
-      // Cast it to a pointer of type of destination operand.
-      PointerType *PtrTy = PointerType::get(DestopTy, 0);
-      IntToPtrInst *ConvIntToPtr = new IntToPtrInst(MemRefValue, PtrTy);
-      getRaisedValues()->setInstMetadataRODataIndex(MemRefValue, ConvIntToPtr);
-      RaisedBB->getInstList().push_back(ConvIntToPtr);
-      MemRefValue = ConvIntToPtr;
-    }
+    // This is an effective address computation
+    // Cast it to a pointer of type of destination operand.
+    PointerType *PtrTy = PointerType::get(DestopTy, 0);
+    IntToPtrInst *ConvIntToPtr = new IntToPtrInst(MemRefValue, PtrTy);
+    getRaisedValues()->setInstMetadataRODataIndex(MemRefValue, ConvIntToPtr);
+    RaisedBB->getInstList().push_back(ConvIntToPtr);
+    MemRefValue = ConvIntToPtr;
   }
   Value *LoadValue = nullptr;
-  if (IsMemRefGlobalVal) {
-    // Load the global value.
-    auto Op = dyn_cast<LoadInst>(MemRefValue)->getPointerOperand();
-    LoadInst *LdInst = new LoadInst(Op->getType()->getPointerElementType(), Op,
-                                    "globalload", false, Align(MemAlignment));
-    LoadValue = getRaisedValues()->setInstMetadataRODataContent(LdInst);
-  } else {
-    LoadInst *LdInst =
-        new LoadInst(MemRefValue->getType()->getPointerElementType(),
-                     MemRefValue, "memload", false, Align(MemAlignment));
-    LoadValue = getRaisedValues()->setInstMetadataRODataContent(LdInst);
-  }
+  LoadInst *LdInst =
+      new LoadInst(MemRefValue->getType()->getPointerElementType(),
+                   MemRefValue, "memload", false, Align(MemAlignment));
+  LoadValue = getRaisedValues()->setInstMetadataRODataContent(LdInst);
 
   // Insert the instruction that loads memory reference
   RaisedBB->getInstList().push_back(dyn_cast<Instruction>(LoadValue));

--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -1869,6 +1869,13 @@ X86MachineInstructionRaiser::getMemoryAddressExprValue(const MachineInstr &MI) {
   // Generate mul scaleAmt, IndexRegVal, if IndexReg is not 0.
   if (IndexReg != X86::NoRegister) {
     Value *IndexRegVal = getPhysRegValue(MI, IndexReg);
+    if (IndexRegVal->getType()->isPointerTy()) {
+      Type *LdTy = IndexRegVal->getType()->getPointerElementType();
+      LoadInst *LdInst =
+        new LoadInst(LdTy, IndexRegVal, "memload", false, Align());
+      RaisedBB->getInstList().push_back(LdInst);
+      IndexRegVal = LdInst;
+    }
     switch (ScaleAmt) {
     case 0:
       assert(false && "Unexpected zero-value of scale in memory operand");

--- a/test/asm_test/X86/raise-basic-globals.s
+++ b/test/asm_test/X86/raise-basic-globals.s
@@ -1,0 +1,266 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: Global: 12
+// CHECK-NEXT: Combined: 17
+// CHECK-NEXT: Global: 17
+// CHECK-NEXT: Global: 7
+// CHECK-EMPTY:
+
+	.text
+	.file	"raise-basic-globals.s"
+	.globl	readGInt                        # -- Begin function readGInt
+	.p2align	4, 0x90
+	.type	readGInt,@function
+readGInt:                               # @readGInt
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	gvar, %esi
+	movabsq	$.L.str, %rdi
+	movb	$0, %al
+	callq	printf
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	readGInt, .Lfunc_end0-readGInt
+	.cfi_endproc
+                                        # -- End function
+	.globl	updateGInt                      # -- Begin function updateGInt
+	.p2align	4, 0x90
+	.type	updateGInt,@function
+updateGInt:                             # @updateGInt
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+	movl	-4(%rbp), %eax
+	addl	gvar, %eax
+	movl	%eax, gvar
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end1:
+	.size	updateGInt, .Lfunc_end1-updateGInt
+	.cfi_endproc
+                                        # -- End function
+	.globl	combinedTest                    # -- Begin function combinedTest
+	.p2align	4, 0x90
+	.type	combinedTest,@function
+combinedTest:                           # @combinedTest
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+	movl	%esi, -8(%rbp)
+	movl	-4(%rbp), %eax
+	addl	gvar, %eax
+	movl	%eax, gvar
+	movl	-8(%rbp), %eax
+	addl	gvar, %eax
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end2:
+	.size	combinedTest, .Lfunc_end2-combinedTest
+	.cfi_endproc
+                                        # -- End function
+	.globl	readGPtr                        # -- Begin function readGPtr
+	.p2align	4, 0x90
+	.type	readGPtr,@function
+readGPtr:                               # @readGPtr
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movq	gptr, %rax
+	movl	(%rax), %esi
+	movabsq	$.L.str, %rdi
+	movb	$0, %al
+	callq	printf
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end3:
+	.size	readGPtr, .Lfunc_end3-readGPtr
+	.cfi_endproc
+                                        # -- End function
+	.globl	updateGPtr                      # -- Begin function updateGPtr
+	.p2align	4, 0x90
+	.type	updateGPtr,@function
+updateGPtr:                             # @updateGPtr
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+	movl	-4(%rbp), %ecx
+	movq	gptr, %rax
+	addl	(%rax), %ecx
+	movl	%ecx, (%rax)
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end4:
+	.size	updateGPtr, .Lfunc_end4-updateGPtr
+	.cfi_endproc
+                                        # -- End function
+	.globl	readGArray                      # -- Begin function readGArray
+	.p2align	4, 0x90
+	.type	readGArray,@function
+readGArray:                             # @readGArray
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	Arr, %esi
+	movabsq	$.L.str, %rdi
+	movb	$0, %al
+	callq	printf
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end5:
+	.size	readGArray, .Lfunc_end5-readGArray
+	.cfi_endproc
+                                        # -- End function
+	.globl	updateGArray                    # -- Begin function updateGArray
+	.p2align	4, 0x90
+	.type	updateGArray,@function
+updateGArray:                           # @updateGArray
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+	movl	-4(%rbp), %eax
+	addl	Arr, %eax
+	movl	%eax, Arr
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end6:
+	.size	updateGArray, .Lfunc_end6-updateGArray
+	.cfi_endproc
+                                        # -- End function
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movl	$15, -8(%rbp)
+	movl	$2, %edi
+	callq	updateGInt
+	callq	readGInt
+	movl	$2, %edi
+	movl	$3, %esi
+	callq	combinedTest
+	movl	%eax, %esi
+	movabsq	$.L.str.1, %rdi
+	movb	$0, %al
+	callq	printf
+	leaq	-8(%rbp), %rax
+	movq	%rax, gptr
+	movl	$2, %edi
+	callq	updateGPtr
+	callq	readGPtr
+	movl	$5, Arr
+	movl	$2, %edi
+	callq	updateGArray
+	callq	readGArray
+	xorl	%eax, %eax
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end7:
+	.size	main, .Lfunc_end7-main
+	.cfi_endproc
+                                        # -- End function
+	.type	gvar,@object                    # @gvar
+	.data
+	.globl	gvar
+	.p2align	2
+gvar:
+	.long	10                              # 0xa
+	.size	gvar, 4
+
+	.type	gptr,@object                    # @gptr
+	.bss
+	.globl	gptr
+	.p2align	3
+gptr:
+	.quad	0
+	.size	gptr, 8
+
+	.type	Arr,@object                     # @Arr
+	.data
+	.globl	Arr
+	.p2align	4
+Arr:
+	.long	0                               # 0x0
+	.long	1                               # 0x1
+	.long	2                               # 0x2
+	.long	3                               # 0x3
+	.size	Arr, 16
+
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Global: %d\n"
+	.size	.L.str, 12
+
+	.type	.L.str.1,@object                # @.str.1
+.L.str.1:
+	.asciz	"Combined: %d\n"
+	.size	.L.str.1, 14
+
+	.ident	"clang version 13.0.0 (https://github.com/llvm/llvm-project.git f5ba3eea6746559513af7ed32db8083ad52661a3)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym readGInt
+	.addrsig_sym printf
+	.addrsig_sym updateGInt
+	.addrsig_sym combinedTest
+	.addrsig_sym readGPtr
+	.addrsig_sym updateGPtr
+	.addrsig_sym readGArray
+	.addrsig_sym updateGArray
+	.addrsig_sym gvar
+	.addrsig_sym gptr
+	.addrsig_sym Arr

--- a/test/asm_test/X86/raise-lea-global.s
+++ b/test/asm_test/X86/raise-lea-global.s
@@ -1,0 +1,62 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: 31
+// CHECK-EMPTY:
+  
+  .text
+	.file	"raise-lea-global.s"
+	.globl	leaGlobal                       # -- Begin function leaGlobal
+	.p2align	4, 0x90
+	.type	leaGlobal,@function
+leaGlobal:                              # @leaGlobal
+	.cfi_startproc
+# %bb.0:                                # %entry
+	movq	gval(%rip), %rax
+	leaq	15(,%rax,8), %rax
+	retq
+.Lfunc_end0:
+	.size	leaGlobal, .Lfunc_end0-leaGlobal
+	.cfi_endproc
+                                        # -- End function
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rax
+	.cfi_def_cfa_offset 16
+	movq	$2, gval(%rip)
+	callq	leaGlobal
+	movl	$.L.str, %edi
+	movq	%rax, %rsi
+	xorl	%eax, %eax
+	callq	printf
+	xorl	%eax, %eax
+	popq	%rcx
+	.cfi_def_cfa_offset 8
+	retq
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+	.cfi_endproc
+                                        # -- End function
+	.type	gval,@object                    # @gval
+	.bss
+	.globl	gval
+	.p2align	3
+gval:
+	.quad	0                               # 0x0
+	.size	gval, 8
+
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"%d\n"
+	.size	.L.str, 4
+
+	.ident	"clang version 13.0.0 (https://github.com/llvm/llvm-project.git f5ba3eea6746559513af7ed32db8083ad52661a3)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig


### PR DESCRIPTION
I encountered this LEA instruction in a benchmark:
leaq 15(,%rax,8), %rax
I've created a test case reproducing this issue.

This patch is also addressing another issue I found with global pointers. When performing a memory-to-register binary operation, the address stored in the pointer was being used in the operation, instead of the data referenced by it.