### PR TITLE
[X86-64] Fix incorrect values in if statement

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -1876,9 +1876,9 @@ bool X86MachineInstructionRaiser::raiseMoveToMemInstr(const MachineInstr &MI,
     auto Opc = MI.getOpcode();
     auto MemSzInBits = getInstructionMemOpSize(Opc) * 8;
     if (isSSE2Instruction(Opc)) {
-      if (MemSzInBits == 4)
+      if (MemSzInBits == 32)
         PtrTy = Type::getFloatPtrTy(Ctx);
-      else if (MemSzInBits == 8)
+      else if (MemSzInBits == 64)
         PtrTy = Type::getDoublePtrTy(Ctx);
       else
         llvm_unreachable("Unhandled memory access size of SSE2 instruction");


### PR DESCRIPTION
The statements used are checking `MemSzInBitz` against incorrect values. This PR fixes that issue