### PR TITLE
[X86-64] Handle EFlags in getReachingDef if multiple reaching defs found

### DIFF
--- a/X86/X86RaisedValueTracker.cpp
+++ b/X86/X86RaisedValueTracker.cpp
@@ -359,10 +359,17 @@ Value *X86RaisedValueTracker::getReachingDef(unsigned int PhysReg, int MBBNo,
     }
 
     Align typeAlign(DL.getPrefTypeAlignment(AllocTy));
-    auto typeSize = AllocTy->getPrimitiveSizeInBits() / 8;
+    auto typeSize =
+        isEflagBit(PhysReg) ? 1 : AllocTy->getPrimitiveSizeInBits() / 8;
 
     const TargetRegisterInfo *TRI = MF.getRegInfo().getTargetRegisterInfo();
-    StringRef PhysRegName = TRI->getRegAsmName(PhysReg);
+    StringRef PhysRegName;
+    if (isEflagBit(PhysReg)) {
+      PhysRegName = StringRef(getEflagName(PhysReg));
+    } else {
+      PhysRegName = TRI->getRegAsmName(PhysReg);
+    }
+
     // Create alloca instruction to allocate stack slot
     AllocaInst *Alloca = new AllocaInst(AllocTy, allocaAddrSpace, 0, typeAlign,
                                         PhysRegName + "-SKT-LOC");


### PR DESCRIPTION
If more than one reaching definition of an EFlag was found, the code was not prepared to handle that scenario:

* `typeSize` would be 0 (integer division: `1 / 8`)
* `getRegAsmName` crashes when called with an EFlag as parameter