### PR TITLE
[X86-64] Add support for IMUL64rm

### DIFF
--- a/X86/X86AdditionalInstrInfo.cpp
+++ b/X86/X86AdditionalInstrInfo.cpp
@@ -925,7 +925,7 @@ static constexpr const_addl_instr_info::value_type mapdata[] = {
     {X86::IMUL32rri8, {0, BINARY_OP_WITH_IMM}},
     {X86::IMUL64m, {0, Unknown}},
     {X86::IMUL64r, {8, BINARY_OP_RR}},
-    {X86::IMUL64rm, {8, Unknown}},
+    {X86::IMUL64rm, {8, BINARY_OP_RM}},
     {X86::IMUL64rmi32, {8, Unknown}},
     {X86::IMUL64rmi8, {8, Unknown}},
     {X86::IMUL64rr, {0, BINARY_OP_RR}},

--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -1364,7 +1364,8 @@ bool X86MachineInstructionRaiser::raiseBinaryOpMemToRegInstr(
     BinOpInst = BinaryOperator::CreateOr(DestValue, LoadValue);
   } break;
   case X86::IMUL16rm:
-  case X86::IMUL32rm: {
+  case X86::IMUL32rm:
+  case X86::IMUL64rm: {
     // One-operand form of IMUL
     // Create mul instruction
     BinOpInst = BinaryOperator::CreateMul(DestValue, LoadValue);

--- a/test/asm_test/X86/raise-imul64rm.s
+++ b/test/asm_test/X86/raise-imul64rm.s
@@ -1,0 +1,35 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -O0 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: 10
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "raise-imul64rm.s"
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    mov rsi, 1
+    imul rsi, [.L.val]
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    xor rax, rax
+    ret
+
+
+.type   .L.str,@object                  # @.str
+.section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "%d\n"
+    .size   .L.str, 10
+
+.section    .rodata.cst8,"aM",@progbits,8
+.L.val:
+    .quad 0xA # int64_t 10


### PR DESCRIPTION
This PR adds support for `IMUL64rm`. This case is handled exactly like `IMUL32rm` and `IMUL16rm`.