### PR TITLE
[X86-64] Cast Alloca to correct type in promotePhysregToStackSlot

### DIFF
--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -871,6 +871,16 @@ StoreInst *X86MachineInstructionRaiser::promotePhysregToStackSlot(
       CInst->insertBefore(TermInst);
     ReachingValue = CInst;
   }
+  if (StackLocTy != Alloca->getType()->getPointerElementType()) {
+    CastInst *CInst = CastInst::Create(
+        CastInst::getCastOpcode(Alloca, false, StackLocTy->getPointerTo(), false),
+        Alloca, StackLocTy->getPointerTo());
+    if (TermInst == nullptr)
+      ReachingBB->getInstList().push_back(CInst);
+    else
+      CInst->insertBefore(TermInst);
+    Alloca = CInst;
+  }
   StInst = new StoreInst(ReachingValue, Alloca, false, Align());
   if (TermInst == nullptr)
     ReachingBB->getInstList().push_back(StInst);


### PR DESCRIPTION
If the type for the stack slot is unknown (incoming edges from BBs that have not been raised yet), it is set to a [64-bit integer](https://github.com/microsoft/llvm-mctoll/blob/master/X86/X86RaisedValueTracker.cpp#L363).

This commit handles this case and casts the stack slot to StackLocTy (e.g. double instead of i64).

