### PR TITLE
[X86-64] Discover XMM0 as return register as well as RAX

### DIFF
--- a/X86/X86FuncPrototypeDiscovery.cpp
+++ b/X86/X86FuncPrototypeDiscovery.cpp
@@ -170,20 +170,9 @@ Type *X86MachineInstructionRaiser::getFunctionReturnType() {
   // defined.
   if (returnType == nullptr) {
     for (MachineBasicBlock &MBB : MF) {
-      int MBBNo = MBB.getNumber();
-      // Get the register definition map of MBB
-      auto MBBDefinedPhysRegIter = PerMBBDefinedPhysRegMap.find(MBBNo);
-      if (MBBDefinedPhysRegIter != PerMBBDefinedPhysRegMap.end()) {
-        // If found, get the value defined for X86::RAX
-        MCPhysRegSizeMap DefinedPhysRegMap = MBBDefinedPhysRegIter->second;
-        auto DefinedPhysRegMapIter = DefinedPhysRegMap.find(X86::RAX);
-        // If RAX is defined by the end of the block, get the type. If found,
-        // this is a block with tail call. So, the return of the tail call is
-        // the return of this function as well.
-        if (DefinedPhysRegMapIter != DefinedPhysRegMap.end()) {
-          returnType = Type::getIntNTy(MF.getFunction().getContext(),
-                                       DefinedPhysRegMapIter->second * 8);
-        }
+      auto DiscoveredReturnType = getReachingReturnType(MBB);
+      if (DiscoveredReturnType != nullptr) {
+        returnType = DiscoveredReturnType;
       }
     }
   }

--- a/test/asm_test/X86/discover-ret-type.s
+++ b/test/asm_test/X86/discover-ret-type.s
@@ -1,0 +1,68 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -O0 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: 3.0
+// CHECK: 10
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "discover-ret-ty.s"
+
+.p2align    4, 0x90
+.type    func1,@function
+func1:
+    addsd xmm0, xmm0
+    ret
+    # int3 instruction after ret, so mctoll won't discover this BB as a return block
+    # int3 is frequently inserted by clang-13 as a padding after functions
+    int3
+
+.p2align    4, 0x90
+.type    func2,@function
+func2:
+    mov eax, edi
+    ret
+    # int3 instruction after ret, so mctoll won't discover this BB as a return block
+    # int3 is frequently inserted by clang-13 as a padding after functions
+    int3
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    sub rsp, 8
+    movsd xmm0, [.L.val]
+
+    call func1
+
+    movabs rdi, offset .L.str
+    mov al, 1
+    call printf
+
+    mov edi, 0xa
+    call func2
+    mov esi, eax
+    movabs rdi, offset .L.str.1
+    mov al, 0
+    call printf
+
+    add rsp, 8
+    xor rax, rax
+    ret
+
+
+.type   .L.str,@object                  # @.str
+.section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "%.1f\n"
+    .size   .L.str, 6
+.L.str.1:
+    .asciz  "%d\n"
+    .size   .L.str.1, 4
+
+.section    .rodata.cst8,"aM",@progbits,8
+.L.val:
+    .quad 0x3ff8000000000000 # double 1.5


### PR DESCRIPTION
If mctoll is unable to discover the return block of a function, it would look at all the basic blocks, if `RAX`, `EAX`, ... is defined, set the return type accordingly. This commit changes this to use the `getReachingReturnType` function, which also supports discovering FP types returned with the `XMM0` register.

mctoll is not able to discover the return type for functions, which are padded with `int3` after the return instruction. I've encountered clang-13 inserting `int3` instead of `nop` as padding. I've added a test with a single `int3` instruction after the return instruction to reproduce this in the test case.