### PR TITLE
[X86-64] Don't initialize externally defined variables

### DIFF
--- a/ARM/ARMMIRevising.cpp
+++ b/ARM/ARMMIRevising.cpp
@@ -14,7 +14,7 @@
 #include "ARMMIRevising.h"
 #include "ARMModuleRaiser.h"
 #include "ARMSubtarget.h"
-#include "ExternalFunctions.h"
+#include "IncludedFileInfo.h"
 #include "MCInstRaiser.h"
 #include "MachineFunctionRaiser.h"
 #include "llvm/BinaryFormat/ELF.h"
@@ -169,7 +169,7 @@ uint64_t ARMMIRevising::getCalledFunctionAtPLTOffset(uint64_t PLTEndOff,
         // Set CallTargetIndex for plt offset to map undefined function symbol
         // for emit CallInst use.
         Function *CalledFunc =
-            ExternalFunctions::Create(*CalledFuncSymName, *MR);
+            IncludedFileInfo::CreateFunction(*CalledFuncSymName, *MR);
         // Bail out if function prototype is not available
         if (!CalledFunc)
           exit(-1);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_subdirectory(test)
 add_llvm_tool(llvm-mctoll
   llvm-mctoll.cpp
   COFFDump.cpp
-  ExternalFunctions.cpp
+        IncludedFileInfo.cpp
   FunctionFilter.cpp
   MachODump.cpp
   ModuleRaiser.cpp

--- a/FunctionFilter.cpp
+++ b/FunctionFilter.cpp
@@ -30,7 +30,7 @@ FunctionFilter::~FunctionFilter() {
 }
 
 /// Get the data type corresponding to type string. These correspond to type
-/// strings generated in ExternalFunctions.cpp upon parsing user specified
+/// strings generated in IncludedFileInfo.cpp upon parsing user specified
 /// include files with external function prototypes.
 Type *FunctionFilter::getPrimitiveDataType(const StringRef &TypeStr) {
   LLVMContext &CTX = M.getContext();

--- a/IncludedFileInfo.cpp
+++ b/IncludedFileInfo.cpp
@@ -1,4 +1,4 @@
-//===-- ExternalFunctions.cpp -----------------------------------*- C++ -*-===//
+//===-- IncludedFileInfo.cpp -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "ExternalFunctions.h"
+#include "IncludedFileInfo.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
@@ -32,8 +32,10 @@
 // as Type being used in this file are from clang namespace and not from llvm
 // namespace.
 
-std::map<std::string, ExternalFunctions::RetAndArgs>
-    ExternalFunctions::UserSpecifiedFunctions;
+std::map<std::string, IncludedFileInfo::RetAndArgs>
+    IncludedFileInfo::ExternalFunctions;
+
+std::set<std::string> IncludedFileInfo::ExternalVariables;
 
 // FuncDeclVisitor
 
@@ -46,7 +48,7 @@ public:
   }
 
   bool VisitFunctionDecl(clang::FunctionDecl *FuncDecl) {
-    ExternalFunctions::RetAndArgs Entry;
+    IncludedFileInfo::RetAndArgs Entry;
     clang::QualType RetTy = FuncDecl->getDeclaredReturnType();
     Entry.ReturnType =
         getUnqualifiedTypeString(RetTy, FuncDecl->getASTContext());
@@ -62,17 +64,17 @@ public:
     // function name to detect duplicate function prototype specification. Need
     // to update this check to include argument types when support to raise C++
     // binary is added.
-    if (ExternalFunctions::UserSpecifiedFunctions.find(
+    if (IncludedFileInfo::ExternalFunctions.find(
             FuncDecl->getQualifiedNameAsString()) !=
-        ExternalFunctions::UserSpecifiedFunctions.end()) {
+        IncludedFileInfo::ExternalFunctions.end()) {
       LLVM_DEBUG(dbgs() << FuncDecl->getQualifiedNameAsString()
                         << " : Ignoring duplicate entry at "
                         << FuncDecl->getLocation().printToString(
                                Context.getSourceManager())
                         << "\n");
     } else {
-      ExternalFunctions::UserSpecifiedFunctions.insert(
-          std::pair<std::string, ExternalFunctions::RetAndArgs>(
+      IncludedFileInfo::ExternalFunctions.insert(
+          std::pair<std::string, IncludedFileInfo::RetAndArgs>(
               FuncDecl->getQualifiedNameAsString(), Entry));
       LLVM_DEBUG(dbgs() << FuncDecl->getQualifiedNameAsString()
                         << " : Entry found at "
@@ -161,13 +163,17 @@ public:
     auto Decls = Context.getTranslationUnitDecl()->decls();
     clang::SourceManager &SourceManager(Context.getSourceManager());
     for (auto &Decl : Decls) {
-      if (!Decl->isFunctionOrFunctionTemplate())
-        continue;
-      const auto &FileID = SourceManager.getFileID(Decl->getLocation());
-      if (FileID != SourceManager.getMainFileID())
-        continue;
-      clang::FunctionDecl *FuncDecl = Decl->getAsFunction();
-      Visitor.TraverseFunctionDecl(FuncDecl);
+      if (Decl->isFunctionOrFunctionTemplate()) {
+        const auto &FileID = SourceManager.getFileID(Decl->getLocation());
+        if (FileID != SourceManager.getMainFileID())
+          continue;
+        clang::FunctionDecl *FuncDecl = Decl->getAsFunction();
+        Visitor.TraverseFunctionDecl(FuncDecl);
+      } else if (Decl->getKind() == clang::Decl::Kind::Var) {
+        auto VarDecl = dyn_cast<clang::VarDecl>(Decl);
+        IncludedFileInfo::ExternalVariables.insert(
+            VarDecl->getQualifiedNameAsString());
+      }
     }
   }
 };
@@ -183,7 +189,7 @@ public:
 };
 
 // Construct and return a Function* corresponding to a known external function
-Function *ExternalFunctions::Create(StringRef &CFuncName, ModuleRaiser &MR) {
+Function *IncludedFileInfo::CreateFunction(StringRef &CFuncName, ModuleRaiser &MR) {
   Module *M = MR.getModule();
   assert(M != nullptr && "Uninitialized ModuleRaiser!");
 
@@ -191,15 +197,15 @@ Function *ExternalFunctions::Create(StringRef &CFuncName, ModuleRaiser &MR) {
   if (Func != nullptr)
     return Func;
 
-  auto iter = ExternalFunctions::UserSpecifiedFunctions.find(CFuncName.str());
-  if (iter == ExternalFunctions::UserSpecifiedFunctions.end()) {
+  auto iter = IncludedFileInfo::ExternalFunctions.find(CFuncName.str());
+  if (iter == IncludedFileInfo::ExternalFunctions.end()) {
     errs() << "Unknown prototype for function : " << CFuncName.data() << "\n";
     errs() << "Use -I </full/path/to/file>, where /full/path/to/file declares "
               "its prototype\n";
     return nullptr;
   }
 
-  const ExternalFunctions::RetAndArgs &retAndArgs = iter->second;
+  const IncludedFileInfo::RetAndArgs &retAndArgs = iter->second;
   Type *RetType =
       MR.getFunctionFilter()->getPrimitiveDataType(retAndArgs.ReturnType);
   std::vector<Type *> ArgVec;
@@ -227,7 +233,7 @@ Function *ExternalFunctions::Create(StringRef &CFuncName, ModuleRaiser &MR) {
   return nullptr;
 }
 
-bool ExternalFunctions::getUserSpecifiedFuncPrototypes(
+bool IncludedFileInfo::getExternalFunctionPrototype(
     std::vector<std::string> &FileNames, std::string &CompDBDir) {
   static llvm::cl::OptionCategory InclFileParseCategory(
       "parse-header-files options");
@@ -274,6 +280,18 @@ bool ExternalFunctions::getUserSpecifiedFuncPrototypes(
   }
 
   return true;
+}
+
+bool IncludedFileInfo::IsExternalVariable(std::string Name) {
+  // If there is a suffix like stdout@@GLIBC_2.2.5, remove it to check
+  // if the symbol is defined in a user-passed header file
+  auto NameEnd = Name.find("@@");
+  if (NameEnd != std::string::npos) {
+    Name = Name.substr(0, NameEnd);
+  }
+  // Declare external global variables as external and don't initalize them
+  return IncludedFileInfo::ExternalVariables.find(Name) !=
+      IncludedFileInfo::ExternalVariables.end();
 }
 
 #undef DEBUG_TYPE

--- a/IncludedFileInfo.h
+++ b/IncludedFileInfo.h
@@ -1,4 +1,4 @@
-//===-- ExternalFunctions.h -------------------------------------*- C++ -*-===//
+//===-- IncludedFileInfo.h -------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_TOOLS_LLVM_MCTOLL_EXTERNALFUNCTIONS_H
-#define LLVM_TOOLS_LLVM_MCTOLL_EXTERNALFUNCTIONS_H
+#ifndef LLVM_TOOLS_LLVM_MCTOLL_INCLUDEDFILEINFO_H
+#define LLVM_TOOLS_LLVM_MCTOLL_INCLUDEDFILEINFO_H
 
 #include "ModuleRaiser.h"
 #include "llvm/IR/Function.h"
@@ -19,9 +19,9 @@
 
 using namespace llvm;
 
-class ExternalFunctions {
-  ExternalFunctions(){};
-  ~ExternalFunctions(){};
+class IncludedFileInfo {
+  IncludedFileInfo(){};
+  ~IncludedFileInfo(){};
 
 public:
   typedef struct RetAndArgs_t {
@@ -30,12 +30,17 @@ public:
     bool isVariadic;
   } RetAndArgs;
 
-  static Function *Create(StringRef &CFuncName, ModuleRaiser &MR);
+  static Function *CreateFunction(StringRef &CFuncName, ModuleRaiser &MR);
+
   // Table of user specified function prototypes
-  static std::map<std::string, ExternalFunctions::RetAndArgs>
-      UserSpecifiedFunctions;
-  static bool getUserSpecifiedFuncPrototypes(std::vector<string> &FileNames,
+  static std::map<std::string, IncludedFileInfo::RetAndArgs> ExternalFunctions;
+
+  static std::set<std::string> ExternalVariables;
+
+  static bool getExternalFunctionPrototype(std::vector<string> &FileNames,
                                              std::string &CompDBDir);
+
+  static bool IsExternalVariable(std::string Name);
 };
 
-#endif // LLVM_TOOLS_LLVM_MCTOLL_EXTERNALFUNCTIONS_H
+#endif // LLVM_TOOLS_LLVM_MCTOLL_INCLUDEDFILEINFO_H

--- a/RISCV/RISCV32MachineInstructionRaiser.cpp
+++ b/RISCV/RISCV32MachineInstructionRaiser.cpp
@@ -1,4 +1,4 @@
-#include "ExternalFunctions.h"
+#include "IncludedFileInfo.h"
 #include "MachineFunctionRaiser.h"
 #include "RISCV32ModuleRaiser.h"
 #include "llvm-mctoll.h"

--- a/X86/X86FuncPrototypeDiscovery.cpp
+++ b/X86/X86FuncPrototypeDiscovery.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "ExternalFunctions.h"
+#include "IncludedFileInfo.h"
 #include "MachineFunctionRaiser.h"
 #include "X86InstrBuilder.h"
 #include "X86MachineInstructionRaiser.h"

--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "X86MachineInstructionRaiser.h"
-#include "ExternalFunctions.h"
+#include "IncludedFileInfo.h"
 #include "MachineFunctionRaiser.h"
 #include "X86InstrBuilder.h"
 #include "X86ModuleRaiser.h"

--- a/X86/X86MachineInstructionRaiserSSE.cpp
+++ b/X86/X86MachineInstructionRaiserSSE.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "ExternalFunctions.h"
+#include "IncludedFileInfo.h"
 #include "X86MachineInstructionRaiser.h"
 #include "X86RaisedValueTracker.h"
 #include "X86RegisterUtils.h"

--- a/llvm-mctoll.cpp
+++ b/llvm-mctoll.cpp
@@ -12,7 +12,7 @@
 
 #include "llvm-mctoll.h"
 #include "EmitRaisedOutputPass.h"
-#include "ExternalFunctions.h"
+#include "IncludedFileInfo.h"
 #include "MCInstOrData.h"
 #include "MachineFunctionRaiser.h"
 #include "ModuleRaiser.h"
@@ -1603,7 +1603,7 @@ int main(int argc, char **argv) {
   std::vector<string> InclFNames(InclFNameSet.begin(), InclFNameSet.end());
 
   if (!InclFNames.empty()) {
-    if (!ExternalFunctions::getUserSpecifiedFuncPrototypes(InclFNames,
+    if (!IncludedFileInfo::getExternalFunctionPrototype(InclFNames,
                                                            CompilationDBDir)) {
       dbgs() << "Unable to read external function prototype. Ignoring\n";
     }

--- a/test/smoke_test/fprintf.c
+++ b/test/smoke_test/fprintf.c
@@ -1,0 +1,19 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: x = 0, y = 0, z = 1
+// CHECK-EMPTY
+
+#include <stdio.h>
+
+int x;
+int y = 0;
+int z = 1;
+
+int main() {
+  fprintf(stdout, "x = %d, y = %d, z = %d\n", x, y, z);
+
+  return 0;
+}


### PR DESCRIPTION
Previously, variables like stdout, stderr, ... were initialized with 0.
This would crash raised programs. Now, we check if they are declared in one of the
passed header files, and don't initialize them in this case.

Before this commit, the following code would generate this declaration in the raised llvm bitcode:
```c
int main() {
  fprintf(stdout, "Hello world!\n");
  return 0;
}
```

```ll
@stdout = common dso_local global i64 0, align 8
```

After this commit, `@stdout` is initialized like this:

```ll
@stdout = external dso_local global i64, align 8
```

To check if a symbol needs no initialization and should be declared as `external`, we check the header files passed via the cli through `-I` flags. Before raising, we save all variables declared in the header files in a set. Later, we check if the symbol is defined in the set. If it is defined, don't initialize it and set the linkage to `ExternalLinkage`.  
Should the name of an encountered symbol be in format `stdout@@GLIBC_2.5.5`, we check the substring up until the `@@`.


One further thing that could be done later is look at the type of the symbol in the passed header file and set the correct type accordingly.
