### PR TITLE
[X86-64] Detect return type for tail-calls in getRaisedFunctionPrototype

### DIFF
--- a/test/smoke_test/tail-call-ret-type.c
+++ b/test/smoke_test/tail-call-ret-type.c
@@ -1,0 +1,30 @@
+// REQUIRES: system-linux
+// RUN: clang -O3 -fno-inline -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: 4^2 = 16
+// CHECK-EMPTY
+
+#include <stdio.h>
+
+int mul(int x, int y) {
+  return x * y;
+}
+
+int square(int x) {
+  // this call should be compiled to a tail-call
+  return mul(x, x);
+}
+
+void unused() {
+  if (square(2) > 0) {
+    printf("2^2 > 0\n");
+  }
+}
+
+int main() {
+  int val = 4;
+  printf("%d^2 = %d\n", val, square(val));
+  return 0;
+}


### PR DESCRIPTION
If a function has a tail-call, set the return type for the function to the return type of the tail-called function in `getRaisedFunctionPrototype`.

In some cases, this would lead to issues initially, as the return type would be set to a type, which would then be used by function calls. When raising the function, the correct return type would be discovered, and the function signature updated accordingly. This then leads to incorrect bitcode.

I've added one test case which crashes while raising without this commit and now passes and outputs the correct bitcode.