### PR TITLE
[X86-64] Detect implicitly-set registers in getPhysRegDefiningInstInB…

### DIFF
--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -453,13 +453,14 @@ const MachineInstr *X86MachineInstructionRaiser::getPhysRegDefiningInstInBlock(
       break;
     }
 
-    // If the instruction has a define
+    // Look if PhysReg is either an explicit or implicit register def
     if (MI.getNumDefs() > 0) {
-      for (auto MO : MI.defs()) {
-        // If the define operand is a register
-        if (MO.isReg()) {
+      for (auto MO : MI.operands()) {
+        // Consider only the register operand
+        if (MO.isReg() && MO.isDef()) {
           unsigned MOReg = MO.getReg();
-          if (Register::isPhysicalRegister(MOReg)) {
+          // If it is a physical register other than EFLAGS
+          if (MOReg != X86::EFLAGS && Register::isPhysicalRegister(MOReg)) {
             if (SuperReg == find64BitSuperReg(MOReg))
               return &MI;
           }

--- a/test/smoke_test/test-implicit-register.c
+++ b/test/smoke_test/test-implicit-register.c
@@ -1,0 +1,33 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -O0 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: 0 % 2 = 0
+// CHECK: 1 % 2 = 1
+// CHECK: 2 % 2 = 0
+// CHECK: 3 % 2 = 1
+// CHECK: 4 % 2 = 0
+// CHECK: 5 % 2 = 1
+// CHECK: 6 % 2 = 0
+// CHECK: 7 % 2 = 1
+// CHECK: 8 % 2 = 0
+// CHECK: 9 % 2 = 1
+// CHECK-EMPTY
+
+#include <stdio.h>
+
+void mod(int n) {
+  // the remainder of the division n / 2 will be saved in edx, which is the register
+  // where it should be for the printf call
+  // This test checks that mctoll recognizes that the sdiv instruction will
+  // implicitly set edx
+  printf("%d %% 2 = %d\n", n, n % 2);
+}
+
+int main(void) {
+  for (int i = 0; i < 10; ++i) {
+    mod(i);
+  }
+  return 0;
+}


### PR DESCRIPTION
This fixes the issue that implicitly defined registers would not be
recognized as parameters for vararg calls. An example would be the following code:

```c
void mod(int n) {
  printf("%d && 2 = &d", n, n % 2);
}
```

This function translates to the following assembly code:

```s
mod:                                    # @mod
        push    rbp
        mov     rbp, rsp
        sub     rsp, 16
        mov     dword ptr [rbp - 4], edi
        mov     esi, dword ptr [rbp - 4]
        mov     eax, dword ptr [rbp - 4]
        mov     ecx, 2
        cdq
        idiv    ecx    ; <-- implicitly defines edx
        movabs  rdi, offset .L.str
        mov     al, 0
        call    printf ; <-- edx is the third parameter for the printf call
        add     rsp, 16
        pop     rbp
        ret
```
