### PR TITLE
[X86-64] Fix memory referencing idiv instructions

### DIFF
--- a/X86/X86MachineInstructionRaiser.h
+++ b/X86/X86MachineInstructionRaiser.h
@@ -135,6 +135,7 @@ private:
   bool raiseInplaceMemOpInstr(const MachineInstr &, Value *);
   bool raiseMoveToMemInstr(const MachineInstr &, Value *);
   bool raiseMoveFromMemInstr(const MachineInstr &, Value *);
+  bool raiseDivideFromMemInstr(const MachineInstr &, Value *);
   bool raiseDivideInstr(const MachineInstr &, Value *);
   bool raiseLoadIntToFloatRegInstr(const MachineInstr &, Value *);
   bool raiseStoreIntToFloatRegInstr(const MachineInstr &, Value *);

--- a/test/smoke_test/div-mem.c
+++ b/test/smoke_test/div-mem.c
@@ -1,0 +1,60 @@
+// REQUIRES: system-linux
+// RUN: clang -O1 -fno-inline -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK-EMPTY
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK: 0  1  2  3  4  5  6  7  8  9
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <inttypes.h>
+
+typedef struct {
+  int32_t len;
+  int64_t len64;
+} Params;
+
+void loop(Params *params) {
+  for (int32_t i = 0; i < params->len * params->len; ++i) {
+    if (i > 0 && i % params->len == 0)
+      printf("\n");
+    printf("%d  ", i % params->len);
+  }
+  printf("\n\n");
+  for (int64_t i = 0; i < params->len64 * params->len64; ++i) {
+    if (i > 0 && i % params->len64 == 0)
+      printf("\n");
+    printf("%" PRId64 "  ", i % params->len64);
+  }
+  printf("\n");
+}
+
+int main(void) {
+  Params params;
+  params.len = 10;
+  params.len64 = 10;
+
+  loop(&params);
+
+  return 0;
+}


### PR DESCRIPTION
Memory referencing instructions like
```s
idiv [rcx]
```
would be translated as if they were
```s
idiv rcx
```
i.e. using the address stored in rcx as the divisor, and not performing the memory load. This PR fixes that