### PR TITLE
[X86-64] Fix argument discovery for vararg functions

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -4510,6 +4510,8 @@ bool X86MachineInstructionRaiser::raiseCallMachineInstr(
             // No blocks visited in this walk up the predecessor P
             BitVector BlockVisited(MF.getNumBlockIDs(), false);
 
+            // CurMBB has already been visited. Mark it so.
+            BlockVisited.set(CurMBB->getNumber());
             // Start at predecessor P
             WorkList.push_back(P);
 
@@ -4536,10 +4538,7 @@ bool X86MachineInstructionRaiser::raiseCallMachineInstr(
                       WorkList.push_back(P);
                   }
                 }
-              } else if (PredMBB->getNumber() == CurMBB->getNumber())
-                // This is a loop. Simply increment ReachDefPredEdgeCount to
-                // indicate that we have a reaching def.
-                ReachDefPredEdgeCount++;
+              }
             }
           }
           // If there is a reaching def on all predecessor edges then consider

--- a/test/asm_test/X86/raise-vararg-args.s
+++ b/test/asm_test/X86/raise-vararg-args.s
@@ -1,0 +1,136 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -O0 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: Swapping 1 and 8
+// CHECK: Swapping 2 and 7
+// CHECK: Swapping 3 and 6
+// CHECK: Swapping 4 and 5
+// CHECK-EMPTY
+
+	.text
+	.intel_syntax noprefix
+	.file	"discover-varargs.s"
+
+// swap_bytes function adapted from
+// https://github.com/kozyraki/phoenix/blob/master/phoenix-2.0/tests/histogram/histogram-seq.c#L70
+	.globl	swap_bytes              # -- Begin function swap_bytes
+	.p2align	4, 0x90
+	.type	swap_bytes,@function
+swap_bytes:                             # @swap_bytes
+	.cfi_startproc
+# %bb.0:
+	push	rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset rbp, -16
+	mov	rbp, rsp
+	.cfi_def_cfa_register rbp
+	sub	rsp, 32
+	mov	qword ptr [rbp - 8], rdi
+	mov	dword ptr [rbp - 12], esi
+	mov	dword ptr [rbp - 16], 0
+.LBB0_1:                                # =>This Inner Loop Header: Depth=1
+	mov	eax, dword ptr [rbp - 16]
+	mov	ecx, dword ptr [rbp - 12]
+	mov	dword ptr [rbp - 24], eax # 4-byte Spill
+	mov	eax, ecx
+	cdq
+	mov	ecx, 2
+	idiv	ecx
+	mov	ecx, dword ptr [rbp - 24] # 4-byte Reload
+	cmp	ecx, eax
+	jge	.LBB0_4
+# %bb.2:                                #   in Loop: Header=BB0_1 Depth=1
+	mov	rax, qword ptr [rbp - 8]
+	movsxd	rcx, dword ptr [rbp - 16]
+	movsx	esi, byte ptr [rax + rcx]
+	mov	rax, qword ptr [rbp - 8]
+	mov	edx, dword ptr [rbp - 12]
+	sub	edx, dword ptr [rbp - 16]
+	sub	edx, 1
+	movsxd	rcx, edx
+	movsx	edx, byte ptr [rax + rcx]
+	movabs	rdi, offset .L.str
+	mov	al, 0
+	call	printf
+	mov	rcx, qword ptr [rbp - 8]
+	movsxd	rdi, dword ptr [rbp - 16]
+	mov	r8b, byte ptr [rcx + rdi]
+	mov	byte ptr [rbp - 17], r8b
+	mov	rcx, qword ptr [rbp - 8]
+	mov	edx, dword ptr [rbp - 12]
+	sub	edx, dword ptr [rbp - 16]
+	sub	edx, 1
+	movsxd	rdi, edx
+	mov	r8b, byte ptr [rcx + rdi]
+	mov	rcx, qword ptr [rbp - 8]
+	movsxd	rdi, dword ptr [rbp - 16]
+	mov	byte ptr [rcx + rdi], r8b
+	mov	r8b, byte ptr [rbp - 17]
+	mov	rcx, qword ptr [rbp - 8]
+	mov	edx, dword ptr [rbp - 12]
+	sub	edx, dword ptr [rbp - 16]
+	sub	edx, 1
+	movsxd	rdi, edx
+	mov	byte ptr [rcx + rdi], r8b
+	mov	dword ptr [rbp - 28], eax # 4-byte Spill
+# %bb.3:                                #   in Loop: Header=BB0_1 Depth=1
+	mov	eax, dword ptr [rbp - 16]
+	add	eax, 1
+	mov	dword ptr [rbp - 16], eax
+	jmp	.LBB0_1
+.LBB0_4:
+	add	rsp, 32
+	pop	rbp
+	.cfi_def_cfa rsp, 8
+	ret
+.Lfunc_end0:
+	.size	swap_bytes, .Lfunc_end0-swap_bytes
+	.cfi_endproc
+                                        # -- End function
+	.globl	main                    # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:
+	push	rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset rbp, -16
+	mov	rbp, rsp
+	.cfi_def_cfa_register rbp
+	sub	rsp, 16
+	lea	rdi, [rbp - 8]
+	mov	rax, qword ptr [.Lmain.buf]
+	mov	qword ptr [rbp - 8], rax
+	mov	esi, 8
+	call	swap_bytes
+	xor	eax, eax
+	add	rsp, 16
+	pop	rbp
+	.cfi_def_cfa rsp, 8
+	ret
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+	.cfi_endproc
+                                        # -- End function
+	.type	.L.str,@object          # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Swapping %d and %d\n"
+	.size	.L.str, 20
+
+	.type	.Lmain.buf,@object      # @main.buf
+	.section	.rodata.cst8,"aM",@progbits,8
+.Lmain.buf:
+	.ascii	"\001\002\003\004\005\006\007\b"
+	.size	.Lmain.buf, 8
+
+
+	.ident	"clang version 7.0.1-8+deb10u2 (tags/RELEASE_701/final)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym swap_bytes
+	.addrsig_sym printf
+	.addrsig_sym main


### PR DESCRIPTION
Replace the iterative algorithm to check if a register is defined for a block or all of its predecessors with a recursive one. This fixes a bug where registers would be incorrectly identified as arguments even if they would not be defined in all predecessors.

Let's take the following function as an example:
![Untitled Diagram](https://user-images.githubusercontent.com/17706737/130046969-5d68d1ff-4635-42cf-93ef-4569a1d637aa.png)

In `bb.2`, we reach a vararg function call and need to discover potential argument registers. We find a definition for `rdi`, `rsi`, `rdx` and `rcx` in the same block. We then check if `r8` is defined here, which is not the case.
After that, we check `bb.1`, which does not define `r8` either.
We add `entry` and `bb.3` to the work list, one of which defines `r8`. In the old code, `ReachDefPredEdgeCount` would now be set to 1. This would lead to `ReachDefPredEdgeCount > (unsigned)0) && (ReachDefPredEdgeCount == CurMBB->pred_size()` being evaluated to true, marking `r8` as an argument register. This is incorrect, as we would need a definition of `r8` in `entry` as well for this to be correct.

I've replaced this iterative algorithm with a recursive one, which checks the following for the passed `MBB`:
- If the `MBB` defines the register, return `true`
- If that's not the case, make sure _all_ predecessors define the registers (and there is at least one predecessor)

We also need to make sure that loops are handled properly in this recursive method, which we do by passing a `BitVector` of already visited `MBB`s. If we encounter a visited `MBB`, we just return `true`. I _think_ this is how the old code would handle such loops.

