### PR TITLE
[X86-64] Fix memory accessing issues to allow raising phoenix-2.0/histogram-seq

### DIFF
--- a/X86/X86AdditionalInstrInfo.cpp
+++ b/X86/X86AdditionalInstrInfo.cpp
@@ -481,7 +481,7 @@ static constexpr const_addl_instr_info::value_type mapdata[] = {
     {X86::CMP64mi32, {8, Unknown}},
     {X86::CMP64mi8, {8, Unknown}},
     {X86::CMP64mr, {8, Unknown}},
-    {X86::CMP64ri32, {0, Unknown}},
+    {X86::CMP64ri32, {0, COMPARE}},
     {X86::CMP64ri8, {0, COMPARE}},
     {X86::CMP64rm, {8, Unknown}},
     {X86::CMP64rr, {0, COMPARE}},

--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -2125,15 +2125,6 @@ bool X86MachineInstructionRaiser::raiseMoveToMemInstr(const MachineInstr &MI,
     MemRefVal = convIntToPtr;
   }
 
-  LoadInst *LdInst = nullptr;
-  if (!isMovInst) {
-    // Load the value from memory location
-    auto align =
-        MemRefVal->getPointerAlignment(MR->getModule()->getDataLayout());
-    LdInst = new LoadInst(MemRefVal->getType()->getPointerElementType(),
-                          MemRefVal, "", false, align, RaisedBB);
-  }
-
   // This instruction moves a source value to memory. So, if the types of
   // the source value and that of the memory pointer element are not the
   // same as that of the store size of the instruction, cast them as needed.
@@ -2155,6 +2146,12 @@ bool X86MachineInstructionRaiser::raiseMoveToMemInstr(const MachineInstr &MI,
   SrcValue = getRaisedValues()->castValue(SrcValue, StoreTy, RaisedBB);
 
   if (!isMovInst) {
+    // Load the value from memory location
+    auto align =
+        MemRefVal->getPointerAlignment(MR->getModule()->getDataLayout());
+    LoadInst *LdInst =
+        new LoadInst(MemRefVal->getType()->getPointerElementType(), MemRefVal,
+                     "", false, align, RaisedBB);
     // If this is not an instruction that just moves SrcValue, generate the
     // instruction that performs the appropriate operation and then store the
     // result in MemRefVal.

--- a/test/asm_test/X86/raise-cmp.s
+++ b/test/asm_test/X86/raise-cmp.s
@@ -1,0 +1,53 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: 256 == 256 = 1
+// CHECK-NEXT: 255 == 256 = 0
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "raise-cmp.s"
+
+.p2align    4, 0x90
+.type    cmp64ri32,@function
+cmp64ri32:
+    cmp rdi, 256
+    jne .ne
+    mov rax, 1
+    ret
+.ne:
+    mov rax, 0
+    ret
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    mov rdi, 256
+    call cmp64ri32
+    mov rdx, rax
+    mov rsi, 256
+    mov rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    mov rdi, 255
+    call cmp64ri32
+    mov rdx, rax
+    mov rsi, 255
+    mov rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    xor rax, rax
+    ret
+
+
+.type   .L.str,@object                  # @.str
+.section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "%d == 256 = %d\n"
+    .size   .L.str, 16

--- a/test/asm_test/X86/raise-indexreg-int.s
+++ b/test/asm_test/X86/raise-indexreg-int.s
@@ -1,0 +1,55 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: byte[0] = dd
+// CHECK-NEXT: byte[1] = cc
+// CHECK-NEXT: byte[2] = bb
+// CHECK-NEXT: byte[3] = aa
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "raise-cindexreg-int.s"
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    mov eax, 0xAABBCCDD
+    push rax
+
+    mov rbx, 0
+
+    movzx edx, byte ptr [rsp + rbx + 0]
+    mov esi, 0
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+    movzx edx, byte ptr [rsp + rbx + 1]
+    mov esi, 1
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+    movzx edx, byte ptr [rsp + rbx + 2]
+    mov esi, 2
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+    movzx edx, byte ptr [rsp + rbx + 3]
+    mov esi, 3
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    add rsp, 8
+    xor rax, rax
+    ret
+
+
+.type   .L.str,@object                  # @.str
+.section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "byte[%d] = %x\n"
+    .size   .L.str, 4

--- a/test/smoke_test/stack-increment.c
+++ b/test/smoke_test/stack-increment.c
@@ -1,0 +1,106 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s -O3 -mno-sse
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h -I /usr/include/string.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: red[0] = 0
+// CHECK-NEXT: green[0] = 0
+// CHECK-NEXT: blue[0] = 0
+// CHECK-NEXT: red[1] = 0
+// CHECK-NEXT: green[1] = 0
+// CHECK-NEXT: blue[1] = 1
+// CHECK-NEXT: red[2] = 0
+// CHECK-NEXT: green[2] = 1
+// CHECK-NEXT: blue[2] = 0
+// CHECK-NEXT: red[3] = 1
+// CHECK-NEXT: green[3] = 0
+// CHECK-NEXT: blue[3] = 0
+// CHECK-NEXT: red[4] = 0
+// CHECK-NEXT: green[4] = 0
+// CHECK-NEXT: blue[4] = 1
+// CHECK-NEXT: red[5] = 0
+// CHECK-NEXT: green[5] = 1
+// CHECK-NEXT: blue[5] = 0
+// CHECK-NEXT: red[6] = 1
+// CHECK-NEXT: green[6] = 0
+// CHECK-NEXT: blue[6] = 0
+// CHECK-NEXT: red[7] = 0
+// CHECK-NEXT: green[7] = 0
+// CHECK-NEXT: blue[7] = 1
+// CHECK-NEXT: red[8] = 0
+// CHECK-NEXT: green[8] = 1
+// CHECK-NEXT: blue[8] = 0
+// CHECK-NEXT: red[9] = 1
+// CHECK-NEXT: green[9] = 0
+// CHECK-NEXT: blue[9] = 0
+// CHECK-NEXT: red[10] = 0
+// CHECK-NEXT: green[10] = 0
+// CHECK-NEXT: blue[10] = 1
+// CHECK-NEXT: red[11] = 0
+// CHECK-NEXT: green[11] = 1
+// CHECK-NEXT: blue[11] = 0
+// CHECK-NEXT: red[12] = 1
+// CHECK-NEXT: green[12] = 0
+// CHECK-NEXT: blue[12] = 0
+// CHECK-NEXT: red[13] = 0
+// CHECK-NEXT: green[13] = 0
+// CHECK-NEXT: blue[13] = 1
+// CHECK-NEXT: red[14] = 0
+// CHECK-NEXT: green[14] = 1
+// CHECK-NEXT: blue[14] = 0
+// CHECK-NEXT: red[15] = 1
+// CHECK-NEXT: green[15] = 0
+// CHECK-NEXT: blue[15] = 0
+// CHECK-NEXT: red[16] = 0
+// CHECK-NEXT: green[16] = 0
+// CHECK-NEXT: blue[16] = 1
+// CHECK-NEXT: red[17] = 0
+// CHECK-NEXT: green[17] = 1
+// CHECK-NEXT: blue[17] = 0
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+  int size;
+  char *data;
+} Params;
+
+__attribute__((noinline)) void test(Params params) {
+  int red[256];
+  int green[256];
+  int blue[256];
+
+  memset(&(red[0]), 0, sizeof(int) * 256);
+  memset(&(green[0]), 0, sizeof(int) * 256);
+  memset(&(blue[0]), 0, sizeof(int) * 256);
+
+  for (int i = 0; i < params.size; i += 3) {
+    unsigned char *val = (unsigned char *)&(params.data[i]);
+    blue[*val]++;
+
+    val = (unsigned char *)&(params.data[i + 1]);
+    green[*val]++;
+
+    val = (unsigned char *)&(params.data[i + 2]);
+    red[*val]++;
+  }
+
+  for (int i = 0; i < 18; i++) {
+    printf("red[%d] = %d\n", i, red[i]);
+    printf("green[%d] = %d\n", i, green[i]);
+    printf("blue[%d] = %d\n", i, blue[i]);
+  }
+}
+
+int main(void) {
+  Params params;
+  params.size = 18;
+  char data[18] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
+  params.data = data;
+
+  test(params);
+
+  return 0;
+}


### PR DESCRIPTION
This PR contains three separate changes that allow raising the [phoenix-2.0 histogram-seq](https://github.com/kozyraki/phoenix/blob/master/phoenix-2.0/tests/histogram/histogram-seq.c) benchmark with `-O1` optimization level:

- Support for missing `CMP64ri32` instruction
- Allow index register type to be int64 type for memory accesses
At `-O1` the compiler generates code that performs integer operations on the index register. This results in mctoll recognizing this register as an integer, not pointer value. This commit allows int64 values for the index register. I've a test to verify this.
- Cast MemRefVal to expected type in raiseMovToMemInstr
Again at `-O1`, the compiler generates code where mctoll, while raising `ADD32mi8`, would recognize `MemRefVal` as an `i64*` instead of the correct type `i32*`. This commit fixes that and casts `MemRefVal` to the correct pointer type _before_ loading `MemRefVal` from memory.

With these changes, the histogram-seq benchmark can be raised at `-O1` opt level.

- I'm not sure if I can include the phoenix benchmark in this repo. I've added the license in the file, I think this should be fine, but I'm no legal expert.
- Should I move the new test to a separate directory, like dhrystone?
