### PR TITLE
Fix stack promotion of moved registers

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -786,46 +786,62 @@ bool X86MachineInstructionRaiser::raiseBinaryOpRegToRegMachineInstr(
   std::vector<Value *> ExplicitSrcValues;
   int MBBNo = MI.getParent()->getNumber();
   bool Success = true;
+  unsigned opc = MI.getOpcode();
 
-  for (const MachineOperand &MO : MI.explicit_uses()) {
-    assert(MO.isReg() &&
-           "Unexpected non-register operand in binary op instruction");
-    auto UseOpIndex = MI.findRegisterUseOperandIdx(MO.getReg(), false, nullptr);
-    Value *SrcValue = getRegOperandValue(MI, UseOpIndex);
+  // Check if this instruction is a xor reg1, reg1 instruction, and does not need
+  // to look up the value of the operand values
+  bool IsXorSetZeroInstruction =
+      (opc == X86::XOR64rr || opc == X86::XOR32rr || opc == X86::XOR16rr ||
+       opc == X86::XOR8rr || opc == X86::XORPSrr || opc == X86::XORPDrr ||
+       opc == X86::PXORrr) &&
+      (MI.findTiedOperandIdx(1) == 0 &&
+       MI.getOperand(DestOpIndex).getReg() ==
+           MI.getOperand(UseOp2Index).getReg());
 
-    ExplicitSrcValues.push_back(SrcValue);
-  }
+  // If we are raising a xor instruction that's just zeroing-out a register,
+  // we don't need to look up the register operand values
+  if (!IsXorSetZeroInstruction) {
+    for (const MachineOperand &MO : MI.explicit_uses()) {
+      assert(MO.isReg() &&
+             "Unexpected non-register operand in binary op instruction");
+      auto UseOpIndex =
+          MI.findRegisterUseOperandIdx(MO.getReg(), false, nullptr);
+      Value *SrcValue = getRegOperandValue(MI, UseOpIndex);
 
-  // Verify the instruction has 1 or 2 use operands
-  assert((ExplicitSrcValues.size() == 1 || ((ExplicitSrcValues.size() == 2))) &&
-         "Unexpected number of operands in register binary op instruction");
+      ExplicitSrcValues.push_back(SrcValue);
+    }
 
-  // If the instruction has two use operands, ensure that their values are
-  // of the same type and non-pointer type.
-  if (ExplicitSrcValues.size() == 2) {
-    Value *Src1Value = ExplicitSrcValues.at(0);
-    Value *Src2Value = ExplicitSrcValues.at(1);
-    // The user operand values can be null if the instruction is 'xor op
-    // op'. See below.
-    if ((Src1Value != nullptr) && (Src2Value != nullptr)) {
-      // If this is a pointer type, convert it to int type
-      while (Src1Value->getType()->isPointerTy()) {
-        PtrToIntInst *ConvPtrToInst = new PtrToIntInst(
-            Src1Value, Src1Value->getType()->getPointerElementType());
-        RaisedBB->getInstList().push_back(ConvPtrToInst);
-        Src1Value = ConvPtrToInst;
-      }
+    // Verify the instruction has 1 or 2 use operands
+    assert(
+        (ExplicitSrcValues.size() == 1 || ((ExplicitSrcValues.size() == 2))) &&
+        "Unexpected number of operands in register binary op instruction");
 
-      // If this is a pointer type, convert it to int type
-      while (Src2Value->getType()->isPointerTy()) {
-        PtrToIntInst *ConvPtrToInst = new PtrToIntInst(
-            Src2Value, Src2Value->getType()->getPointerElementType());
-        RaisedBB->getInstList().push_back(ConvPtrToInst);
-        Src2Value = ConvPtrToInst;
-      }
-      assert(((Src1Value->getType()->isIntegerTy() &&
-               Src2Value->getType()->isIntegerTy()) ||
-              (Src1Value->getType()->isFloatingPointTy() &&
+    // If the instruction has two use operands, ensure that their values are
+    // of the same type and non-pointer type.
+    if (ExplicitSrcValues.size() == 2) {
+      Value *Src1Value = ExplicitSrcValues.at(0);
+      Value *Src2Value = ExplicitSrcValues.at(1);
+      // The user operand values can be null if the instruction is 'xor op
+      // op'. See below.
+      if ((Src1Value != nullptr) && (Src2Value != nullptr)) {
+        // If this is a pointer type, convert it to int type
+        while (Src1Value->getType()->isPointerTy()) {
+          PtrToIntInst *ConvPtrToInst = new PtrToIntInst(
+              Src1Value, Src1Value->getType()->getPointerElementType());
+          RaisedBB->getInstList().push_back(ConvPtrToInst);
+          Src1Value = ConvPtrToInst;
+        }
+
+        // If this is a pointer type, convert it to int type
+        while (Src2Value->getType()->isPointerTy()) {
+          PtrToIntInst *ConvPtrToInst = new PtrToIntInst(
+              Src2Value, Src2Value->getType()->getPointerElementType());
+          RaisedBB->getInstList().push_back(ConvPtrToInst);
+          Src2Value = ConvPtrToInst;
+        }
+        assert(((Src1Value->getType()->isIntegerTy() &&
+                 Src2Value->getType()->isIntegerTy()) ||
+                (Src1Value->getType()->isFloatingPointTy() &&
                Src2Value->getType()->isFloatingPointTy()) ||
               (Src1Value->getType()->isVectorTy() &&
                Src2Value->getType()->isVectorTy())) &&
@@ -844,6 +860,7 @@ bool X86MachineInstructionRaiser::raiseBinaryOpRegToRegMachineInstr(
       }
       ExplicitSrcValues[0] = Src1Value;
       ExplicitSrcValues[1] = Src2Value;
+      }
     }
   }
 
@@ -851,7 +868,6 @@ bool X86MachineInstructionRaiser::raiseBinaryOpRegToRegMachineInstr(
   // binary operator.
   unsigned int dstReg = X86::NoRegister;
   Value *dstValue = nullptr;
-  unsigned opc = MI.getOpcode();
   // Construct the appropriate binary operation instruction
   switch (opc) {
   case X86::ADD8rr:
@@ -1043,7 +1059,6 @@ bool X86MachineInstructionRaiser::raiseBinaryOpRegToRegMachineInstr(
   case X86::XOR64rr: {
     // Verify the def operand is a register.
     const MachineOperand &DestOp = MI.getOperand(DestOpIndex);
-    const MachineOperand &Use2Op = MI.getOperand(UseOp2Index);
     assert(DestOp.isReg() && "Expecting destination of xor instruction to "
                              "be a register operand");
     assert((MCID.getNumDefs() == 1) &&
@@ -1053,7 +1068,7 @@ bool X86MachineInstructionRaiser::raiseBinaryOpRegToRegMachineInstr(
     // Generate an or instruction to set the zero flag if the
     // operands are the same. An instruction such as 'xor $ecx, ecx' is
     // generated to set the register value to 0.
-    if ((MI.findTiedOperandIdx(1) == 0) && (dstReg == Use2Op.getReg())) {
+    if (IsXorSetZeroInstruction) {
       // No instruction to generate. Just set destReg value to 0.
       Type *DestTy = getPhysRegOperandType(MI, 0);
       Value *Val = ConstantInt::get(DestTy, 0, false /* isSigned */);
@@ -1360,11 +1375,8 @@ bool X86MachineInstructionRaiser::raiseBinaryOpRegToRegMachineInstr(
     // - perform the operation
     // - bitcast back to original type
     dstReg = MI.getOperand(DestOpIndex).getReg();
-    bool isXorOperation =
-        opc == X86::XORPDrr || opc == X86::XORPSrr || opc == X86::PXORrr;
 
-    if (isXorOperation && (MI.findTiedOperandIdx(1) == 0) &&
-        (dstReg == MI.getOperand(UseOp2Index).getReg())) {
+    if (IsXorSetZeroInstruction) {
       // No instruction to generate. Just set destReg value to 0.
       Type *DestTy = getPhysRegOperandType(MI, 0);
       dstValue = ConstantFP::get(DestTy, 0);

--- a/test/asm_test/X86/mov-reaching-def.s
+++ b/test/asm_test/X86/mov-reaching-def.s
@@ -1,0 +1,56 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -O0 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h -I /usr/include/string.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: format string length: 25
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "ramov-reaching-def.s"
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    movabs rdi, offset .L.str
+    call strlen # eax defined here
+    cmp eax, 0 # access eax here, before the bb that will store in the store location
+    je .eq
+
+.neq:
+    mov esi, eax # store should occur here
+    cmp eax, 0 # this instruction still accesses eax, not the stack location
+    jne .before_print
+
+.eq:
+    mov esi, 0 # store should occur here
+    jmp .print
+
+.before_print:
+    mov ebx, esi
+    cmp ebx, 0
+    jne .before_print_1
+
+    mov esi, 0
+    jmp .print
+
+
+.before_print_1:
+    mov esi, ebx
+
+.print:
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf # this will access the stack location
+
+    xor eax, eax
+    ret
+
+
+.type   .L.str,@object                  # @.str
+.section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "format string length: %d\n"
+    .size   .L.str, 26


### PR DESCRIPTION
This PR consists of two commits:

1. [X86-64] Do not look up values for xor operations that set a register… 
2. [X86-64] Only replace dominating uses of promoted register with load … 

I had to include commit 1., as without it, commit 2. would expose a bug that previously existed, but did not fail mctoll's unit tests.

1. Do not look up register operand values for `xor eax, eax` instructions that just zero out a register. I've encountered issues where `getRegOperandValue` would generate a `load` instruction from a promoted stack slot. The loaded value was not used, but no issues would arise during tests.
```s
main:
    movabs rdi, offset .L.str
    call strlen # rax defined here
    cmp eax, 0
    je .eq

.neq:
    mov esi, eax
    cmp eax, 0
    jne .print

.eq:
    mov esi, 0
    jmp .print

.print:
    movabs rdi, offset .L.str
    mov al, 0
    xor esi, esi
    call printf

    xor eax, eax
    ret
```

The above, compiled and raised, would generate the following output (just relevant parts shown here):

```ll
define dso_local i32 @main() {
entry:
  %ESI-SKT-LOC = alloca i32, align 4
  %EAX = call i32 @strlen(i8* getelementptr inbounds ([30 x i8], [30 x i8]* @rodata_11, i32 0, i32 4))
  %ld-stk-prom8 = load i32, i32* %ESI-SKT-LOC, align 4
  %0 = sub i32 %ld-stk-prom8, 0 ; <-- (A) loading from stack slot, but stack slot has not been written yet!
  %ZF = icmp eq i32 %0, 0
  %CmpZF_JE = icmp eq i1 %ZF, true
  br i1 %CmpZF_JE, label %bb.2, label %bb.1

bb.1:                                             ; preds = %entry
  %6 = sub i32 %EAX, 0
  %7 = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %EAX, i32 0)
  %CF1 = extractvalue { i32, i1 } %7, 1
  %ZF2 = icmp eq i32 %6, 0
  store i32 %EAX, i32* %ESI-SKT-LOC, align 1
  %CmpZF_JNE = icmp eq i1 %ZF2, false
  br i1 %CmpZF_JNE, label %bb.3, label %bb.2

bb.2:                                             ; preds = %bb.1, %entry
  store i32 0, i32* %ESI-SKT-LOC, align 1
  br label %bb.3

bb.3:                                             ; preds = %bb.2, %bb.1
  %ESI = load i32, i32* %ESI-SKT-LOC, align 1 ; <-- (B) not needed!
  %EAX9 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([30 x i8], [30 x i8]* @rodata_11, i32 0, i32 4), i32 0)
  ret i32 0
}
```

After commit 1, (B) won't be generated in the code anymore.

In the above code, you can also see the issue that commit 2 fixes. Since we are doing `mov esi, eax` in `bb.1`, mctoll replaces _all_ uses of `%EAX` with a load from the stack slot. This is seen at (A) in the above code. `ESI-SKT-LOC` has not been written yet, but we're loading from the stack slot. This commit now just replaces uses if they dominate the store to the stack slot.

`test/asm_test/X86/mov-reaching-def.s` is raised to the following after commit 2.:

```ll
define dso_local i32 @main() {
entry:
  %RSI-SKT-LOC = alloca i32, align 4
  %EAX = call i32 @strlen(i8* getelementptr inbounds ([30 x i8], [30 x i8]* @rodata_11, i32 0, i32 4))
  %0 = sub i32 %EAX, 0 ; <-- Using %EAX here!
  %ZF = icmp eq i32 %0, 0
  %CmpZF_JE = icmp eq i1 %ZF, true
  br i1 %CmpZF_JE, label %bb.2, label %bb.1

bb.1:                                             ; preds = %entry
  %6 = sub i32 %EAX, 0
  %ZF2 = icmp eq i32 %6, 0
  store i32 %EAX, i32* %RSI-SKT-LOC, align 1 ; <-- store happening here, after this all uses will be loaded from stack slot
  %CmpZF_JNE = icmp eq i1 %ZF2, false
  br i1 %CmpZF_JNE, label %bb.3, label %bb.2

bb.2:                                             ; preds = %bb.1, %entry
  store i32 0, i32* %RSI-SKT-LOC, align 1
  br label %bb.3

bb.3:                                             ; preds = %bb.2, %bb.1
  %12 = load i32, i32* %RSI-SKT-LOC, align 1 ; <-- load from stack slot
  %RSI = zext i32 %12 to i64
  %EAX7 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([30 x i8], [30 x i8]* @rodata_11, i32 0, i32 4), i64 %RSI)
  ret i32 0
}
```
