### PR TITLE
[X86-64] Add `unreachable` instruction after `__assert_fail` calls

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -4722,10 +4722,21 @@ bool X86MachineInstructionRaiser::raiseCallMachineInstr(
     }
     // Add 'unreachable' instruction after callInst if it is a call to glibc
     // function 'void exit(int)'
+    // 'void __assert_fail(char *, char *, unsigned int, char *)'
     if (CalledFunc->getName().equals("exit")) {
       FunctionType *FT = CalledFunc->getFunctionType();
       if (FT->getReturnType()->isVoidTy() && (FT->getNumParams() == 1) &&
           FT->getParamType(0)->isIntegerTy(32)) {
+        Instruction *UR = new UnreachableInst(Ctx);
+        RaisedBB->getInstList().push_back(UR);
+      }
+    } else if (CalledFunc->getName().equals("__assert_fail")) {
+      FunctionType *FT = CalledFunc->getFunctionType();
+      if (FT->getReturnType()->isVoidTy() && FT->getNumParams() == 4 &&
+          FT->getParamType(0)->isPointerTy() &&
+          FT->getParamType(1)->isPointerTy() &&
+          FT->getParamType(2)->isIntegerTy() &&
+          FT->getParamType(3)->isPointerTy()) {
         Instruction *UR = new UnreachableInst(Ctx);
         RaisedBB->getInstList().push_back(UR);
       }

--- a/test/smoke_test/assert.c
+++ b/test/smoke_test/assert.c
@@ -1,0 +1,16 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s -O2
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h -I /usr/include/assert.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: argc == 1
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <assert.h>
+
+int main(int argc, char **argv) {
+  assert(argc == 1);
+  printf("argc == 1\n");
+  return 0;
+}


### PR DESCRIPTION
This allows mctoll to raise programs optimized with -O1 or greater. Previously those would fail, as basic blocks calling `__assert_fail` would not have a terminating instruction.