### PR TITLE
External functions: use `ASTContext.getTypeInfo` to get int type width

### DIFF
--- a/IncludedFileInfo.cpp
+++ b/IncludedFileInfo.cpp
@@ -106,43 +106,31 @@ private:
 
     // Construct type string corresponding to the buitl-in type
     if (CurUnQTy->isBuiltinType()) {
-      std::string TypeStr;
       const clang::BuiltinType *BltInTy = CurUnQTy->getAs<clang::BuiltinType>();
-      switch (BltInTy->getKind()) {
-      case clang::BuiltinType::Kind::Char_S:
-      case clang::BuiltinType::Kind::Char_U:
-      case clang::BuiltinType::Kind::UChar:
-      case clang::BuiltinType::Kind::Bool:
-        UnQTyStr.append("i8");
-        break;
-      case clang::BuiltinType::Kind::Short:
-      case clang::BuiltinType::Kind::UShort:
-        UnQTyStr.append("i16");
-        break;
-      case clang::BuiltinType::Kind::Int:
-      case clang::BuiltinType::Kind::UInt:
-      case clang::BuiltinType::Kind::Long:
-      case clang::BuiltinType::Kind::ULong:
-        UnQTyStr.append("i32");
-        break;
-      case clang::BuiltinType::Kind::LongLong:
-      case clang::BuiltinType::Kind::ULongLong:
-        UnQTyStr.append("i64");
-        break;
-      case clang::BuiltinType::Kind::Float:
-        UnQTyStr.append("float");
-        break;
-      case clang::BuiltinType::Kind::Double:
-        UnQTyStr.append("double");
-        break;
-      case clang::BuiltinType::Kind::LongDouble:
-        UnQTyStr.append("ldouble");
-        break;
-      case clang::BuiltinType::Kind::Void:
-        UnQTyStr.append("void");
-        break;
-      default:
-        assert(false && "Unhandled builtin type found in include file");
+      if (BltInTy->isInteger()) {
+        auto FieldInfo = ASTCtx.getTypeInfo(CurUnQTy);
+        uint64_t TypeWidth = FieldInfo.Width;
+        assert((TypeWidth == 64 || TypeWidth == 32 || TypeWidth == 16 ||
+                TypeWidth == 8) &&
+               "Unexpected builtin type width encountered");
+        UnQTyStr.append("i" + to_string(TypeWidth));
+      } else {
+        switch (BltInTy->getKind()) {
+        case clang::BuiltinType::Kind::Float:
+          UnQTyStr.append("float");
+          break;
+        case clang::BuiltinType::Kind::Double:
+          UnQTyStr.append("double");
+          break;
+        case clang::BuiltinType::Kind::LongDouble:
+          UnQTyStr.append("ldouble");
+          break;
+        case clang::BuiltinType::Kind::Void:
+          UnQTyStr.append("void");
+          break;
+        default:
+          assert(false && "Unhandled builtin type found in include file");
+        }
       }
       // Append any pointer qualifiers
       UnQTyStr.append(PointerStr);

--- a/test/smoke_test/Inputs/param-long.c
+++ b/test/smoke_test/Inputs/param-long.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include "param-long.h"
+
+void test(unsigned long int x) {
+  printf("test(0x%lx)\n", x);
+}

--- a/test/smoke_test/Inputs/param-long.h
+++ b/test/smoke_test/Inputs/param-long.h
@@ -1,0 +1,6 @@
+#ifndef LLVM_PROJECT_PARAM_LONG_H
+#define LLVM_PROJECT_PARAM_LONG_H
+
+void test(unsigned long int x);
+
+#endif // LLVM_PROJECT_PARAM_LONG_H

--- a/test/smoke_test/param-long-test.c
+++ b/test/smoke_test/param-long-test.c
@@ -1,0 +1,17 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t.so %s -shared -fPIC
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h -I %S/Inputs/param-long.h %t.so
+// RUN: clang -o %t1 %S/Inputs/param-long.c %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: test(0x7fffffffffffffff)
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <limits.h>
+
+extern void test(long int x);
+
+int main() {
+  test(LONG_MAX);
+  return 0;
+}


### PR DESCRIPTION
Previously, `long` and `unsigned long` were incorrectly detected as `i32` for X86_64 (see added test case). We now use ASTCtx.getTypeInfo to correctly identify the correct integer type for the current platform.

It would have worked as well to move `clang::BuiltinType::Kind::Long` and `clang::BuiltinType::Kind::ULong` to the `i64` branch, but I think errors like these are avoided if we query llvm for the appropriate type width, especially should mctoll add support for additional architectures in the future.