### PR TITLE
[X86-64] Sign-extend `MOV64ri32` immediate

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -292,8 +292,11 @@ bool X86MachineInstructionRaiser::raiseMoveImmToRegMachineInstr(
     Type *ImmTy = getImmOperandType(MI, 1);
     Value *SrcValue = ConstantInt::get(ImmTy, SrcImm);
 
-    SrcValue = getRaisedValues()->castValue(
-        SrcValue, getPhysRegType(DstPReg), getRaisedBasicBlock(MI.getParent()));
+    bool SignExtend = Opcode == X86::MOV64ri32;
+
+    SrcValue = getRaisedValues()->castValue(SrcValue, getPhysRegType(DstPReg),
+                                            getRaisedBasicBlock(MI.getParent()),
+                                            SignExtend);
 
     if (SrcImm > 0) {
       // Check if the immediate value corresponds to a global variable.

--- a/test/smoke_test/ulong_max.c
+++ b/test/smoke_test/ulong_max.c
@@ -1,0 +1,22 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: 0x7fffffffffffffff
+// CHECK: 0xffffffffffffffff
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <limits.h>
+
+void test(long int x) {
+  printf("0x%lx\n", x);
+}
+
+int main() {
+  test(LONG_MAX);
+  test(ULONG_MAX);
+
+  return 0;
+}


### PR DESCRIPTION
`MOV64ri32` should sign-extend the 32 bit immediate, not zero-extend.

https://www.felixcloutier.com/x86/mov 