### PR TITLE
[X86-64] For CMPmi instructions, use the correct type to load from memory

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -2700,7 +2700,10 @@ bool X86MachineInstructionRaiser::raiseCompareMachineInstr(
     if (NonMemRefOp->isReg()) {
       NonMemRefOpTy = getPhysRegOperandType(MI, nonMemRefOpIndex);
     } else if (NonMemRefOp->isImm()) {
-      NonMemRefOpTy = getImmOperandType(MI, nonMemRefOpIndex);
+      LLVMContext &Ctx(MF.getFunction().getContext());
+      auto MemOpSize = getInstructionMemOpSize(MI.getOpcode());
+      assert(MemOpSize != 0 && "Expected mem op size to be > 0");
+      NonMemRefOpTy = Type::getIntNTy(Ctx, MemOpSize * 8);
     } else {
       LLVM_DEBUG(MI.dump());
       assert(false && "Unhandled second operand type in compare instruction");

--- a/test/smoke_test/cmp-mem.c
+++ b/test/smoke_test/cmp-mem.c
@@ -1,0 +1,27 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s -O3 -fno-inline
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: x > 0
+// CHECK-EMPTY
+
+#include <stdio.h>
+
+typedef struct {
+  int x;
+} Data;
+
+void test(Data *data) {
+  if (data->x > 0) {
+    printf("x > 0\n");
+  } else {
+    printf("x <= 0\n");
+  }
+}
+
+int main() {
+  Data data;
+  data.x = 1 << 16;
+  test(&data);
+}


### PR DESCRIPTION
Previously the value from memory would be loaded using the immediate's
type. This would result in the following instruction

```s
cmp [rdi + 8], 0
```

being raised to the following:

```ll
%0 = inttoptr i64 %arg1 to i8*
%1 = load i8, i8* %0, align 1 ; loads only one of four bytes
...
```

After this commit, the raised bitcode looks like this:

```ll
%0 = inttoptr i64 %arg1 to i32*
%1 = load i32, i32* %0, align 1
...
```