### PR TITLE
[X86-64] Use `getRaisedFunction()` to insert a new BasicBlock

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -4920,7 +4920,9 @@ bool X86MachineInstructionRaiser::raiseMachineFunction() {
     std::string BBName = MBBNo == 0 ? "entry" : "bb." + std::to_string(MBBNo);
     // Create a BasicBlock instance corresponding to MBB being looked at.
     // The raised form of MachineInstr of MBB will be added to curBlock.
-    BasicBlock *CurIBB = BasicBlock::Create(Ctx, BBName, CurFunction);
+    // Do not use CurFunction here, as CurFunction might change if it's return
+    // type is changed
+    BasicBlock *CurIBB = BasicBlock::Create(Ctx, BBName, getRaisedFunction());
     // Record the mapping of the number of MBB to corresponding BasicBlock.
     // This information is used to raise branch instructions, if any, of the
     // MBB in a later walk of MachineBasicBlocks of MF.

--- a/test/smoke_test/test-void-assert.c
+++ b/test/smoke_test/test-void-assert.c
@@ -1,0 +1,43 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s -O3
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h -I /usr/include/stdlib.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: Ok
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// assert is not supported in llvm-mctoll yet.
+// https://github.com/microsoft/llvm-mctoll/pull/124
+// After this PR is merged, my_assert can be exchanged with assert
+#define my_assert(cond)                                                        \
+  if (!cond) {                                                                 \
+    printf("Assertion " #cond " failed.\n");                                   \
+    exit(1);                                                                   \
+  }
+
+typedef struct {
+  int length;
+  void *data;
+} Data;
+
+__attribute__((noinline)) void assert_func(Data *args) {
+  my_assert(args->length);
+
+  char *data = (char *)(args->data);
+  my_assert(data);
+}
+
+int main(int argc, char *argv[]) {
+  Data args;
+  args.length = 4;
+  args.data = "asdf";
+
+  assert_func(&args);
+
+  printf("Ok\n");
+
+  return 0;
+}


### PR DESCRIPTION
If a function's return type gets changed, but there are still BB's left to be inserted, CurFunction will not point to the modified function.
This commit fixes this by always querying for the current function.

The added test case compiles to the following:

```s
assert_func:                            # @assert_func
        push    rax
        cmp     dword ptr [rdi], 0
        je      .LBB0_1
        cmp     qword ptr [rdi + 8], 0
        je      .LBB0_4
        pop     rax
        ret
.LBB0_1:
        mov     edi, offset .Lstr
        jmp     .LBB0_2
.LBB0_4:
        mov     edi, offset .Lstr.4
.LBB0_2:
        call    puts@PLT
        mov     edi, 1
        call    exit
```

Initially, llvm-mctoll assumes that this is a function returning `i64`, as `rax` is defined before the `ret` instruction. However, when raising the function, mctoll adjusts the return type to `void`, triggering incorrect behavior, as `LBB0_1` and onwards still need to be raised.