### PR TITLE
Fix `getOperand() out of range!` for `getMCInstIndex` on `RETQ` instr

### DIFF
--- a/MCInstRaiser.cpp
+++ b/MCInstRaiser.cpp
@@ -299,7 +299,9 @@ uint64_t MCInstRaiser::getMCInstSize(uint64_t Offset) const {
 
 uint64_t MCInstRaiser::getMCInstIndex(const MachineInstr &MI) const {
   unsigned NumExpOps = MI.getNumExplicitOperands();
-  const MachineOperand &MO = MI.getOperand(NumExpOps);
+  const MachineOperand &MO = NumExpOps < MI.getNumOperands()
+                                 ? MI.getOperand(NumExpOps)
+                                 : MI.getOperand(MI.getNumOperands() - 1);
   assert(MO.isMetadata() &&
          "Unexpected non-metadata operand in branch instruction");
   const MDNode *MDN = MO.getMetadata();

--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -3048,6 +3048,16 @@ bool X86MachineInstructionRaiser::raiseSetCCMachineInstr(
                                      MI.getParent()->getNumber(), CMP);
     Success = true;
   } break;
+  case X86::COND_AE: {
+    // Check if CF = 0
+    Pred = CmpInst::Predicate::ICMP_EQ;
+    Value *CFValue = getRegOrArgValue(EFLAGS::CF, MBBNo);
+    CmpInst *CMP = new ICmpInst(Pred, CFValue, FalseValue);
+    RaisedBB->getInstList().push_back(CMP);
+    raisedValues->setPhysRegSSAValue(DestOp.getReg(),
+                                     MI.getParent()->getNumber(), CMP);
+    Success = true;
+  } break;
   case X86::COND_A: {
     // Check CF == 0 and ZF == 0
     Value *CFValue = getRegOrArgValue(EFLAGS::CF, MBBNo);

--- a/test/asm_test/X86/raise-setae.s
+++ b/test/asm_test/X86/raise-setae.s
@@ -1,0 +1,46 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -O0 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: SETAE: 0
+// CHECK: SETAE: 1
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "raise-setae.s"
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    xor esi, esi
+    # set CF = 1
+    mov al, 0xff
+    add al, 1
+
+    setae sil
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    xor esi, esi
+    # set CF = 0
+    mov al, 0
+    add al, 1
+
+    setae sil
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    xor rax, rax
+    ret
+
+
+.type   .L.str,@object                  # @.str
+.section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "SETAE: %d\n"
+    .size   .L.str, 11

--- a/test/smoke_test/string-split.c
+++ b/test/smoke_test/string-split.c
@@ -1,0 +1,80 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s -O3 -mno-sse
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h -I /usr/include/stdlib.h -I /usr/include/string.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: hello
+// CHECK: world
+// CHECK: how
+// CHECK: is
+// CHECK: your
+// CHECK: day
+// CHECK: end
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  char *str;
+  int len;
+} Data;
+
+typedef enum {
+  IN_WORD,
+  NOT_IN_WORD
+} State;
+
+void my_print(int len, char *str);
+
+__attribute__((noinline))
+void split_str(Data *data) {
+  State state = NOT_IN_WORD;
+
+  char *curr_start = data->str;
+
+  for (int i = 0; i < data->len; ++i) {
+    char curr = data->str[i];
+    switch (state) {
+    case IN_WORD:
+      if (curr < 'a' || curr > 'z') {
+        data->str[i] = 0;
+        my_print(&data->str[i] - curr_start + 1, curr_start);
+        state = NOT_IN_WORD;
+      }
+      break;
+    case NOT_IN_WORD:
+      if (curr >= 'a' && curr <= 'z') {
+        curr_start = &data->str[i];
+        state = IN_WORD;
+      }
+      break;
+    }
+  }
+
+  if (state == IN_WORD) {
+    data->str[data->len] = 0;
+    my_print(&data->str[data->len] - curr_start + 1, curr_start);
+  }
+}
+
+__attribute__((noinline))
+void my_print(int len, char *str) {
+  printf("%.*s\n", len, str);
+}
+
+
+int main(int argc, char **argv) {
+  Data data;
+  data.str = malloc(35);
+  data.len = 35;
+
+  char *str = "hello, world! how is your day? end";
+  memcpy(data.str, str, 35);
+
+  split_str(&data);
+
+  free(data.str);
+  return 0;
+}


### PR DESCRIPTION
This PR contains two commits:

* Adding support for `setae`, as this is needed to raise the test for the second commit
* The bugfix for `getMCInstIndex`.

The `RETQ` instruction has only a single explicit operand, so `MI.getNumExplicitOperands() == MI.getNumOperands() == 1`.
The only operand is the metadata operand for this instruction, so we access the last operand.
