### PR TITLE
[X86-64] Use correct type for `pxor reg, reg`

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -1367,7 +1367,11 @@ bool X86MachineInstructionRaiser::raiseBinaryOpRegToRegMachineInstr(
         (dstReg == MI.getOperand(UseOp2Index).getReg())) {
       // No instruction to generate. Just set destReg value to 0.
       Type *DestTy = getPhysRegOperandType(MI, 0);
-      dstValue = ConstantFP::get(DestTy, 0);
+      if (DestTy->isFPOrFPVectorTy()) {
+        dstValue = ConstantFP::get(DestTy, 0);
+      } else {
+        dstValue = ConstantInt::get(DestTy, 0);
+      }
     } else {
       LLVMContext &Ctx(MF.getFunction().getContext());
 

--- a/test/asm_test/X86/raise-xorps-xorpd.s
+++ b/test/asm_test/X86/raise-xorps-xorpd.s
@@ -8,6 +8,7 @@
 // CHECK: 1.0
 // CHECK: 0.0
 // CHECK: 0.0
+// CHECK: 0.0
 // CHECK-EMPTY
 
 .text
@@ -33,6 +34,15 @@ test_xorp_zero:
 .type    test_pxor,@function
 test_pxor:
     pxor xmm0, xmm1
+    mov al, 1
+    mov rdi, offset .L.str
+    call printf
+    ret
+
+.p2align    4, 0x90
+.type    test_pxor_zero,@function
+test_pxor_zero:
+    pxor xmm0, xmm0
     mov al, 1
     mov rdi, offset .L.str
     call printf
@@ -76,6 +86,9 @@ main:                                   # @main
     movsd xmm0, [.L.val]
     movss xmm1, [.L.val.2]
     call test_xorp_zero
+
+    movsd xmm0, [.L.val]
+    call test_pxor_zero
 
     xor rax, rax
     ret


### PR DESCRIPTION
Previously, `pxor xmm0, xmm0` would incorrectly use `ConstantFP::get`. This is now fixed.