### PR TITLE
Improve the Peephole optimization pass

### DIFF
--- a/PeepholeOptimizationPass.cpp
+++ b/PeepholeOptimizationPass.cpp
@@ -13,6 +13,12 @@
 
 char PeepholeOptimizationPass::ID = 0;
 
+
+/*
+  Raises the level of abstraction of memory operations.
+  This has a significant impact when recompiling the raised program with other
+  optimizations, such as -O2.
+*/
 bool PeepholeOptimizationPass::runOnFunction(Function &F) {
   for (BasicBlock &BB : F) {
     
@@ -24,43 +30,71 @@ bool PeepholeOptimizationPass::runOnFunction(Function &F) {
       if (auto *I2P = dyn_cast<IntToPtrInst>(&I)) {
         Value *V = I2P->getOperand(0);
         if (auto *BinOp = dyn_cast<BinaryOperator>(V)) {
-          /*
-            Simplifies the following pattern:
-              %tos = ptrtoint i8* %stktop_8 to i64
-              %0 = add i64 %tos, 16
-              %RBP_N.8 = inttoptr i64 %0 to i32*
-            replacing them with:
-              %0 = getelementptr i8, i8* %stktop_8, i64 16
-              %RBP_N.8 = bitcast i8* %0 to i32*
-            This has a significant impact when recompiling the raised program with other
-            optimizations, such as -O2.
-          */
-          auto *P2I = dyn_cast<PtrToIntInst>(BinOp->getOperand(0));
-          if (P2I && (BinOp->getOpcode()==Instruction::Add || BinOp->getOpcode()==Instruction::Or)) {
-             auto *Ptr = P2I->getOperand(0);
+	  if (BinOp->getOpcode()==Instruction::Add) {
+             /*
+               Simplifies the following pattern:
+                 %tos = ptrtoint i8* %stktop_8 to i64
+                 %0 = add i64 %tos, 16
+                 %RBP_N.8 = inttoptr i64 %0 to i32*
+               replacing them with:
+                 %0 = getelementptr i8, i8* %stktop_8, i64 16
+                 %RBP_N.8 = bitcast i8* %0 to i32*
+             */
+             auto *P2I = dyn_cast<PtrToIntInst>(BinOp->getOperand(0));
+             if (P2I) {
+               auto *Ptr = P2I->getOperand(0);
   
-             auto *PtrElemTy = dyn_cast<PointerType>(Ptr->getType())->getElementType();
-             if (isa<IntegerType>(PtrElemTy)) {
-               Value *Idx = BinOp->getOperand(1);
-               std::vector<Value*> GEPIdx;
-               GEPIdx.push_back(Idx);
+               auto *PtrElemTy = dyn_cast<PointerType>(Ptr->getType())->getElementType();
+               if (isa<IntegerType>(PtrElemTy)) {
+                 Value *Idx = BinOp->getOperand(1);
+                 std::vector<Value*> GEPIdx;
+                 GEPIdx.push_back(Idx);
 
-               IRBuilder<> Builder(&I);
+                 IRBuilder<> Builder(&I);
 
-               auto *BytePtrTy = PointerType::getUnqual(IntegerType::get(F.getContext(),8));
-               auto *BytePtr = Builder.CreatePointerCast(Ptr, BytePtrTy);
+                 auto *BytePtrTy = PointerType::getUnqual(IntegerType::get(F.getContext(),8));
+                 auto *BytePtr = Builder.CreatePointerCast(Ptr, BytePtrTy);
 
-               auto *GEP = Builder.CreateGEP(BytePtr, GEPIdx);
+                 auto *GEP = Builder.CreateGEP(BytePtr, GEPIdx);
   
-               auto *FinalPtr = Builder.CreatePointerCast(GEP, I2P->getType());
-               I2P->replaceAllUsesWith(FinalPtr);
+                 auto *FinalPtr = Builder.CreatePointerCast(GEP, I2P->getType());
+                 I2P->replaceAllUsesWith(FinalPtr);
 
-               FinalPtr->takeName(I2P);
-               I2P->eraseFromParent();
+                 FinalPtr->takeName(I2P);
+                 I2P->eraseFromParent();
 
-               if (BinOp->getNumUses()==0) BinOp->eraseFromParent();
-               if (P2I->getNumUses()==0) P2I->eraseFromParent();
-             }
+                 if (BinOp->getNumUses()==0) BinOp->eraseFromParent();
+                 if (P2I->getNumUses()==0) P2I->eraseFromParent();
+               }
+	     } else if (isa<Argument>(BinOp->getOperand(0)) && isa<IntegerType>(BinOp->getOperand(0)->getType()) ) {
+                /*
+                  Simplifies the following pattern:
+                    %0 = add i64 %arg, 8
+                    %RBP_N.8 = inttoptr i64 %0 to i64*
+                  eplacing them with:
+                    %0 = inttoptr i64 %arg to i8*
+                    %1 = getelementptr i8, i8* %0, i64 8
+                    %RBP_N.8 = bitcast i8* %1 to i64*
+                */
+                Value *Idx = BinOp->getOperand(1);
+                std::vector<Value*> GEPIdx;
+                GEPIdx.push_back(Idx);
+
+                IRBuilder<> Builder(&I);
+
+                auto *BytePtrTy = PointerType::getUnqual(IntegerType::get(F.getContext(),8));
+                auto *BytePtr = Builder.CreateIntToPtr(BinOp->getOperand(0), BytePtrTy);
+
+                auto *GEP = Builder.CreateGEP(BytePtr, GEPIdx);
+  
+                auto *FinalPtr = Builder.CreatePointerCast(GEP, I2P->getType());
+                I2P->replaceAllUsesWith(FinalPtr);
+
+                FinalPtr->takeName(I2P);
+                I2P->eraseFromParent();
+
+                if (BinOp->getNumUses()==0) BinOp->eraseFromParent();
+	     } 
           }
         } else if (auto *P2I = dyn_cast<PtrToIntInst>(V)) {
 	  /*

--- a/PeepholeOptimizationPass.cpp
+++ b/PeepholeOptimizationPass.cpp
@@ -32,11 +32,11 @@ bool PeepholeOptimizationPass::runOnFunction(Function &F) {
         if (auto *BinOp = dyn_cast<BinaryOperator>(V)) {
 	  if (BinOp->getOpcode()==Instruction::Add) {
              /*
-               Simplifies the following pattern:
+               The code pattern bellow:
                  %tos = ptrtoint i8* %stktop_8 to i64
                  %0 = add i64 %tos, 16
                  %RBP_N.8 = inttoptr i64 %0 to i32*
-               replacing them with:
+               is replaced with:
                  %0 = getelementptr i8, i8* %stktop_8, i64 16
                  %RBP_N.8 = bitcast i8* %0 to i32*
              */
@@ -68,10 +68,10 @@ bool PeepholeOptimizationPass::runOnFunction(Function &F) {
                }
 	     } else if (isa<Argument>(BinOp->getOperand(0)) && isa<IntegerType>(BinOp->getOperand(0)->getType()) ) {
                 /*
-                  Simplifies the following pattern:
+                  The code pattern bellow:
                     %0 = add i64 %arg, 8
                     %RBP_N.8 = inttoptr i64 %0 to i64*
-                  eplacing them with:
+                  is replaced with:
                     %0 = inttoptr i64 %arg to i8*
                     %1 = getelementptr i8, i8* %0, i64 8
                     %RBP_N.8 = bitcast i8* %1 to i64*
@@ -98,9 +98,11 @@ bool PeepholeOptimizationPass::runOnFunction(Function &F) {
           }
         } else if (auto *P2I = dyn_cast<PtrToIntInst>(V)) {
 	  /*
-	    Simplifies the following pattern into a simple pointer casting.
+	    The code pattern bellow:
               %0 = ptrtoint i8* %stktop_8 to i64
               %1 = inttoptr i64 %0 to i32*
+	    is replaced with a simple pointer casting:
+	      %1 = bitcast i8* %stktop_8 to i32*
 	  */
           IRBuilder<> Builder(&I);
           auto *FinalPtr = Builder.CreatePointerCast(P2I->getOperand(0), I2P->getType());


### PR DESCRIPTION
```
define dso_local i64 @foo(i64 %arg1, i32 %arg2) {
...
  %12 = add i64 %arg1, 8
  %13 = inttoptr i64 %12 to i64*
  store i64 %RCX9, i64* %13, align 1
...
}
```

The code above is transformed into the follow code:

```
define dso_local i64 @foo(i64 %arg1, i32 %arg2) {
...
  %12 = inttoptr i64 %arg1 to i8*
  %13 = getelementptr i8, i8* %12, i64 8
  %14 = bitcast i8* %13 to i64*
  store i64 %RCX9, i64* %14, align 1
...
}
```

For example, this transformation can improve future optimizations when `foo` is inlined. It also makes it easier to analyze whether `%arg1` is always used as a pointer,  depending on its `inttoptr` uses.