### PR TITLE
Fix SSE stack promotion

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -4649,6 +4649,12 @@ bool X86MachineInstructionRaiser::raiseCallMachineInstr(
           ArgVal =
               getRaisedValues()->castValue(ArgVal, FuncArg.getType(), RaisedBB);
         }
+      } else {
+        // for varadic arguments, reinterpret vectors as doubles
+        if (ArgVal->getType()->isVectorTy()) {
+          ArgVal = getRaisedValues()->reinterpretSSERegValue(
+              ArgVal, Type::getDoubleTy(Ctx), RaisedBB);
+        }
       }
       assert(ArgVal != nullptr && "Unexpected null argument value");
       CallInstFuncArgs.push_back(ArgVal);
@@ -4749,6 +4755,8 @@ bool X86MachineInstructionRaiser::raiseCallMachineInstr(
   } break;
   case X86::CALL64m:
   case X86::CALL64r: {
+    LLVMContext &Ctxt(MF.getFunction().getContext());
+    BasicBlock *RaisedBB = getRaisedBasicBlock(MI.getParent());
     const MachineBasicBlock *MBB = MI.getParent();
     int MBBNo = MBB->getNumber();
 
@@ -4772,6 +4780,9 @@ bool X86MachineInstructionRaiser::raiseCallMachineInstr(
       if (RD == nullptr) {
         break;
       } else {
+        if (RD->getType()->isVectorTy()) {
+          RD = raisedValues->reinterpretSSERegValue(RD, Type::getDoubleTy(Ctxt), RaisedBB);
+        }
         ArgTypeVector.push_back(RD->getType());
         ArgValueVector.push_back(RD);
       }
@@ -4801,10 +4812,6 @@ bool X86MachineInstructionRaiser::raiseCallMachineInstr(
 
       unsigned LoadOpIndex = 0;
       // Get index of memory reference in the instruction.
-
-      // Get the BasicBlock corresponding to MachineBasicBlock of MI.
-      // Raised instruction is added to this BasicBlock.
-      BasicBlock *RaisedBB = getRaisedBasicBlock(MI.getParent());
 
       // Load the value from memory location of memRefValue.
       // memRefVal is either an AllocaInst (stack access), GlobalValue (global

--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -931,14 +931,14 @@ StoreInst *X86MachineInstructionRaiser::promotePhysregToStackSlot(
   int StackLocSzInBits =
       Alloca->getType()->getPointerElementType()->getPrimitiveSizeInBits();
   Type *StackLocTy;
-  if (ReachingValue->getType()->isIntOrPtrTy() ||
-      ReachingValue->getType()->isVectorTy()) {
+  if (ReachingValue->getType()->isIntOrPtrTy()) {
     // Cast the current value to int64 if needed
     StackLocTy = Type::getIntNTy(Ctxt, StackLocSzInBits);
-  } else if (ReachingValue->getType()->isFloatingPointTy()) {
+  } else if (ReachingValue->getType()->isFloatingPointTy() ||
+             ReachingValue->getType()->isVectorTy()) {
     assert(StackLocSzInBits == 128 &&
-           "Expected FP types to be stored in 128 bit stack location");
-    StackLocTy = Type::getInt128Ty(Ctxt);
+           "Expected FP types and vectors to be stored in 128 bit stack location");
+    StackLocTy = VectorType::get(Type::getInt32Ty(Ctxt), 4, false);
   } else {
     llvm_unreachable("Unhandled type");
   }

--- a/test/asm_test/X86/raise-call64r-float.s
+++ b/test/asm_test/X86/raise-call64r-float.s
@@ -4,6 +4,7 @@
 // RUN: clang -o %t-dis %t-dis.ll
 // RUN: %t-dis 2>&1 | FileCheck %s
 // CHECK: 1.5
+// CHECK-NEXT: 0.0
 // CHECK-EMPTY
 
 .text
@@ -26,6 +27,10 @@ func1:
 main:                                   # @main
     movsd xmm0, [.L.val]
     mov rax, OFFSET func1
+    call rax
+
+    xorps xmm0, xmm0
+    mov rax, offset func1
     call rax
 
     xor rax, rax

--- a/test/smoke_test/float_args_zero.c
+++ b/test/smoke_test/float_args_zero.c
@@ -1,0 +1,12 @@
+// REQUIRES: system-linux
+// RUN: clang -O3 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: cat %t-dis.ll 2>&1 | FileCheck %s
+// CHECK: %{{.*}} = call i32 (i8*, ...) @printf(i8* {{.*}}), double %{{.*}})
+
+#include <stdio.h>
+
+int main() {
+  printf("%.1f\n", 0.0);
+  return 0;
+}

--- a/test/smoke_test/float_stack_promotion.c
+++ b/test/smoke_test/float_stack_promotion.c
@@ -1,0 +1,23 @@
+// REQUIRES: system-linux
+// RUN: clang -O3 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: val = 1.0
+// CHECK-EMPTY
+
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  double val = 1.0;
+
+  if (argc == 2) {
+    val = 2.0;
+  } else if (argc > 2) {
+    val = 3.0;
+  }
+
+  printf("val = %.1f\n", val);
+
+  return 0;
+}


### PR DESCRIPTION
This PR consists of three related commits:

1. Update `reinterpretSSERegValue` to output more efficient code
Previously, `double` -> `<4 x int>` would have resulted in the following bitcode:
```ll
; previously
%0 = bitcast double %arg1 to i64
%1 = zext i64 %0 to i128
%2 = bitcast i128 %1 to <4 x i32>
; now
%0 = insertelement <2 x double> zeroinitializer, double %arg1, i64 0
%1 = bitcast <2 x double> %0 to <4 x i32>
```
Another example for going `<4 x int>` -> `double`:
```ll
; previously
%0 = bitcast <4 x int> %arg1 to i128
%1 = trunc i128 %0 to i64
%2 = bitcast i64 %1 to double
; now
%0 = bitcast <4 x int> %arg1 to <2 x double>
%1 = extractelement <2 x double> %0, i64 0
```

2. Pass variadic arguments as double
  Discovered variadic arguments should always be a `double` or a `float`. When we discover a vector type for an argument, we assume it should be `double`.
3. Save SSE values in a `<4 x i32>` stack slot instead of `i128`
  This changes the type of stack slots for `xmm` registers to `<4 x i32>`. This fixes an issue where values loaded from stack slots would not be treated as SSE values.

I've added tests for commits 2. and 3., but not for 1., as it does not add any functionality. I've checked that all existing tests still pass with the modification.