### PR TITLE
[X86-64] Raising shift: if previous CF value is undefined, assume CF = 0

### DIFF
--- a/X86/X86RaisedValueTracker.cpp
+++ b/X86/X86RaisedValueTracker.cpp
@@ -881,6 +881,11 @@ bool X86RaisedValueTracker::testAndSetEflagSSAValue(unsigned int FlagBit,
       RaisedBB->getInstList().push_back(NewCFInst);
 
       Value *OldCF = physRegDefsInMBB[FlagBit][MBBNo].second;
+      if (OldCF == nullptr) {
+        // if CF is undefined, assume CF = 0
+        LLVMContext &Ctx(MF.getFunction().getContext());
+        OldCF = ConstantInt::get(Type::getInt1Ty(Ctx), 0);
+      }
 
       // Select the value of CF based on Count value being > 0
       Instruction *SelectCF =
@@ -954,6 +959,11 @@ bool X86RaisedValueTracker::testAndSetEflagSSAValue(unsigned int FlagBit,
       RaisedBB->getInstList().push_back(NewCFInst);
 
       Value *OldCF = physRegDefsInMBB[FlagBit][MBBNo].second;
+      if (OldCF == nullptr) {
+        // if CF is undefined, assume CF = 0
+        LLVMContext &Ctx(MF.getFunction().getContext());
+        OldCF = ConstantInt::get(Type::getInt1Ty(Ctx), 0);
+      }
       // Select the value of CF based on Count value being > 0
       Instruction *SelectCF =
           SelectInst::Create(CountValTest, NewCFInst, OldCF, "shld_cf_update");

--- a/test/smoke_test/setbit.c
+++ b/test/smoke_test/setbit.c
@@ -1,0 +1,24 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t-opt %s -O2 -mno-sse
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t-opt
+// RUN: clang -o %t-opt-dis %t-opt-dis.ll
+// RUN: %t-opt-dis 2>&1 | FileCheck %s
+// CHECK: x = 0x02
+
+#include <limits.h> // for CHAR_BIT
+#include <stdio.h>
+
+__attribute__((noinline)) void setbit(char *set, int index, int value) {
+  set += index / CHAR_BIT;
+  if (value)
+    *set |= 1 << (index % CHAR_BIT); /* set bit  */
+  else
+    *set &= ~(1 << (index % CHAR_BIT)); /* clear bit*/
+}
+
+int main() {
+  char x = 0;
+  setbit(&x, 1, 1);
+  printf("x = 0x%02x\n", (int)x);
+  return 0;
+}


### PR DESCRIPTION
This incorrect behaviour happens when a SHL instruction with a non-zero shift amount is raised, and CF is undefined. CF is set to the shifted-out bit, or left unchanged if the shift amount was 0.

I've added a test that failed to raise before this change.
When raising the `SHL` instruction, the CF bit is set to a) the shifted out bit if the shift-amount is non-zero or b) left unchanged.
If the CF value is unknown/undefined while we are raising `SHL`, we now assume that the value was 0 so the program does not crash.

