### PR TITLE
[X86-64] If SymbSize < MemAccessSizeInBytes, set MemAccessSize to SymbSize

### DIFF
--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -1721,6 +1721,11 @@ X86MachineInstructionRaiser::getGlobalVariableValueAt(const MachineInstr &MI,
         if (SymbSize < GlobDataSymAlignment) {
           GlobDataSymAlignment = SymbSize;
         }
+        // if we are trying to access more bytes than the symbol contains, set
+        // MemAccessSizeInBytes to SymbSize
+        if (SymbSize < MemAccessSizeInBytes) {
+          MemAccessSizeInBytes = SymbSize;
+        }
         GlobalValue::LinkageTypes Lnkg;
         switch (Symb->getBinding()) {
         case ELF::STB_GLOBAL:

--- a/test/smoke_test/pass-int-ptr.c
+++ b/test/smoke_test/pass-int-ptr.c
@@ -1,0 +1,22 @@
+// REQUIRES: system-linux
+// RUN: clang -O1 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t1 %t-dis.ll
+// RUN: %t1 2>&1 | FileCheck %s
+// CHECK: 4
+// CHECK-EMPTY
+
+#include <stdio.h>
+
+int x = 4;
+
+__attribute__((noinline))
+void print_int(int *ptr) {
+  printf("%d\n", *ptr);
+}
+
+int main(void) {
+  print_int(&x);
+
+  return 0;
+}


### PR DESCRIPTION
This fixes a crash when a move instruction moves an address of a global int
variable into a 64-bit register, as a MemAccessSize of 8 bytes was assumed.

The following code triggers this issue:

```c
int x = 4;

test(&x);
```

The `&x` is compiled to 

```s
movabs rdi, 2111952
call test
```

Since no memory access size was set for `MOV64ri`, the code used the destination registers size to calculate `MemAccessSizeInBytes`. Since this is greater than `SymbSize`, [this assertion](https://github.com/microsoft/llvm-mctoll/blob/3b2489761e2e498d8095abe639641c1bea05ee12/X86/X86MachineInstructionRaiserUtils.cpp#L1861) failed.

We now set `MemAccessSize` to `SymbSize` if `SymbSize` is less than `MemAccessSize`.


