### PR TITLE
[X86-64] If a BB is not terminated, insert an unreachable instruction

### DIFF
--- a/X86/X86MachineInstructionRaiser.cpp
+++ b/X86/X86MachineInstructionRaiser.cpp
@@ -5173,7 +5173,7 @@ bool X86MachineInstructionRaiser::raiseMachineFunction() {
     }
   }
   return createFunctionStackFrame() && raiseBranchMachineInstrs() &&
-         handleUnpromotedReachingDefs();
+         handleUnpromotedReachingDefs() && handleUnterminatedBlocks();
 }
 
 bool X86MachineInstructionRaiser::raise() {

--- a/X86/X86MachineInstructionRaiser.h
+++ b/X86/X86MachineInstructionRaiser.h
@@ -201,6 +201,7 @@ private:
   Value *getRegOperandValue(const MachineInstr &mi, unsigned OperandIndex);
 
   bool handleUnpromotedReachingDefs();
+  bool handleUnterminatedBlocks();
 
   const MachineInstr *
   getPhysRegDefiningInstInBlock(int PhysReg, const MachineInstr *StartMI,

--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -1068,6 +1068,19 @@ bool X86MachineInstructionRaiser::handleUnpromotedReachingDefs() {
   return true;
 }
 
+// Insert an unreachable instruction at the end of every BB if it is not
+// terminated.
+// We assume that unterminated BBs will never exit
+bool X86MachineInstructionRaiser::handleUnterminatedBlocks() {
+  LLVMContext &Ctx(getRaisedFunction()->getContext());
+  for (auto &BB : *getRaisedFunction()) {
+    if (BB.getTerminator() == nullptr) {
+      new UnreachableInst(Ctx, &BB);
+    }
+  }
+  return true;
+}
+
 // Create a single stack frame based on stack allocations of the Function.
 // The single stack frame thus created is expected to preserve the frame layout
 // of the source binary - as represented by the various stack allocations. This

--- a/test/smoke_test/terminating-func.c
+++ b/test/smoke_test/terminating-func.c
@@ -1,0 +1,23 @@
+// REQUIRES: system-linux
+// RUN: clang -o %t %s -O2
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h -I /usr/include/stdlib.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: Hello from main!
+// CHECK-NEXT: Bye!
+// CHECK-EMPTY
+
+#include <stdio.h>
+#include <stdlib.h>
+
+__attribute__((noinline))
+void exit_with_msg(const char *msg) {
+  printf("%s\n", msg);
+  exit(0);
+}
+
+int main() {
+  printf("Hello from main!\n");
+  exit_with_msg("Bye!");
+  return 0;
+}


### PR DESCRIPTION
If a basic block was unterminated, mctoll would crash while raising it, as subsequent passes would assume that every BB has a terminator instruction. Example:

```c
void exit_with_msg(const char *msg) {
  printf("%s\n", msg);
  exit(0);
}

int main() {
  exit_with_msg("Bye!");
  return 0;
}
```

If `exit_with_msg` is not inlined, the main function is compiled to the following assembly code:


```s
main:                                   # @main
        push    rax
        mov     edi, offset .L.str.1
        call    exit_with_msg
```

With this PR, mctoll generates the following LLVM code instead of crashing:


```ll
define dso_local void @main() {
entry:
  %RSP_P.0 = alloca i64, align 1
  store i64 3735928559, i64* %RSP_P.0, align 8
  %0 = ptrtoint i8* getelementptr inbounds ([26 x i8], [26 x i8]* @rodata_11, i32 0, i32 21) to i64, !ROData_Index !1
  call void @exit_with_msg(i64 %0)
  unreachable
}
```