### PR TITLE
remove leading space from restrict file

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -11,12 +11,12 @@ This may be done in a plain text file with `exclude-functions` and `include-func
 ```
 ; exclude `int bar(int)` defined in a.out
 exclude-functions {
-  a.out:i32 bar(i32)   
+a.out:i32 bar(i32)   
 }
 
 ; include `int foo(void)` defined in a.out
 include-functions {
-  a.out:i32 foo(void)   
+a.out:i32 foo(void)   
 }
 ```
 


### PR DESCRIPTION
If the file is named "a.out" the restrict file would not work correctly because the [regex](https://github.com/microsoft/llvm-mctoll/blob/0983976177568161c22f9882623876eaa84da36b/FunctionFilter.cpp#L287) does not skip whitespaces and would match "   a.out" which is not equal to "a.out". So there should be either no leading spaces or the regex be changed to skip leading -and also trailing would be nice- whitespaces)