### PR TITLE
[X86-64] Add support for SETCCm instructions

### DIFF
--- a/X86/X86AdditionalInstrInfo.cpp
+++ b/X86/X86AdditionalInstrInfo.cpp
@@ -2412,7 +2412,7 @@ static constexpr const_addl_instr_info::value_type mapdata[] = {
     {X86::SEH_SetFrame, {0, Unknown}},
     {X86::SEH_StackAlloc, {0, Unknown}},
     {X86::SETCCr, {0, SETCC}},
-    {X86::SETCCm, {0, SETCC}},
+    {X86::SETCCm, {1, SETCC}},
     {X86::SFENCE, {0, Unknown}},
     {X86::SGDT16m, {0, Unknown}},
     {X86::SGDT32m, {0, Unknown}},

--- a/X86/X86MachineInstructionRaiser.h
+++ b/X86/X86MachineInstructionRaiser.h
@@ -129,7 +129,7 @@ private:
   bool raiseBinaryOpImmToRegMachineInstr(const MachineInstr &);
   bool raiseBinaryOpMRIOrMRCEncodedMachineInstr(const MachineInstr &MI);
   bool raiseBinaryOpMemToRegInstr(const MachineInstr &, Value *);
-  bool raiseSetCCMachineInstr(const MachineInstr &);
+  bool raiseSetCCMachineInstr(const MachineInstr &, Value *);
   bool raiseCallMachineInstr(const MachineInstr &);
   bool raiseCompareMachineInstr(const MachineInstr &, bool, Value *);
   bool raiseInplaceMemOpInstr(const MachineInstr &, Value *);

--- a/test/asm_test/X86/raise-setccm.s
+++ b/test/asm_test/X86/raise-setccm.s
@@ -1,0 +1,49 @@
+// REQUIRES: x86_64-linux
+// RUN: clang -O0 -o %t %s
+// RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
+// RUN: clang -o %t-dis %t-dis.ll
+// RUN: %t-dis 2>&1 | FileCheck %s
+// CHECK: x = 0
+// CHECK-NEXT: x = 1
+// CHECK-EMPTY
+
+.text
+.intel_syntax noprefix
+.file "raise-xor-ri.s"
+
+.globl    main                    # -- Begin function main
+.p2align    4, 0x90
+.type    main,@function
+main:                                   # @main
+    sub rsp, 1
+    mov byte ptr [rsp], 0xff
+
+    mov eax, 1
+    sub eax, 1
+    setne [rsp]
+
+    movzx esi, byte ptr [rsp]
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    mov byte ptr [rsp], 0xff
+
+    mov eax, 1
+    sub eax, 0
+    setne [rsp]
+
+    movzx esi, byte ptr [rsp]
+    movabs rdi, offset .L.str
+    mov al, 0
+    call printf
+
+    add rsp, 1
+    mov eax, 0
+    ret
+
+.type   .L.str,@object                  # @.str
+.section        .rodata.str1.1,"aMS",@progbits,1
+.L.str:
+    .asciz  "x = %d\n"
+    .size   .L.str, 8


### PR DESCRIPTION
Adds support for `SETCCm` instructions.

Example:

```s
setne [rsp]
```