### PR TITLE
[X86-64] Insert unreachable after non-returning calls for all return types

### DIFF
--- a/X86/X86MachineInstructionRaiserUtils.cpp
+++ b/X86/X86MachineInstructionRaiserUtils.cpp
@@ -1076,10 +1076,9 @@ bool X86MachineInstructionRaiser::handleUnterminatedBlocks() {
     if (!BB.empty() && (BB.getTerminator() == nullptr)) {
       // If the last instruction of a basic block is a call instruction
       // convert it into a tail call and insert an unreachable instruction
-      // after the call instruction if
-      // a) this block is an exit block i.e., has no successors.
-      // b) the function has a void return
-      if (succ_empty(&BB) && raisedFunction->getReturnType()->isVoidTy()) {
+      // after the call instruction if this block is an exit block i.e., has no
+      // successors.
+      if (succ_empty(&BB)) {
         Instruction *LastInst = &*(BB.rbegin());
         CallInst *Call = dyn_cast<CallInst>(LastInst);
         if (Call) {

--- a/test/smoke_test/terminating-func.c
+++ b/test/smoke_test/terminating-func.c
@@ -16,8 +16,18 @@ void exit_with_msg(const char *msg) {
   exit(0);
 }
 
+__attribute__((noinline))
+int exit_conditionally(int exit) {
+  if (exit) {
+    exit_with_msg("Bye!");
+    return 0;
+  } else {
+    return printf("Not exiting");
+  }
+}
+
 int main() {
   printf("Hello from main!\n");
-  exit_with_msg("Bye!");
+  exit_conditionally(1);
   return 0;
 }


### PR DESCRIPTION
Marking calls as tail calls and inserting an `unreachable` instruction should be done for all return types.

The C code in `test/smoke_test/terminating-func.c` is compiled and optimized to the following IR [1]:

```ll
; ...
define dso_local i32 @exit_conditionally(i32 %0) local_unnamed_addr #3 !dbg !20 {
  call void @llvm.dbg.value(metadata i32 %0, metadata !25, metadata !DIExpression()), !dbg !26
  %2 = icmp eq i32 %0, 0, !dbg !27
  br i1 %2, label %4, label %3, !dbg !29

3: ; preds = %1
  tail call void @exit_with_msg(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.str.1, i64 0, i64 0)), !dbg !30
  unreachable, !dbg !32

4: ; preds = %1
  %5 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([12 x i8], [12 x i8]* @.str.2, i64 0, i64 0)), !dbg !33
  ret i32 %5, !dbg !35
}
```

[1]: [Compiler Explorer](https://godbolt.org/z/G7dTs7oqx)