### PR TITLE
Remove the branch specifying in git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Support for raising X86-64 and Arm32 binaries is enabled by building LLVM's X86 
 2. Clone the LLVM and mctoll git repositories
 
 ```sh
-git clone -b master https://github.com/llvm/llvm-project.git
+git clone https://github.com/llvm/llvm-project.git
 cd llvm-project && git clone -b master https://github.com/microsoft/llvm-mctoll.git llvm/tools/llvm-mctoll
 ```
 


### PR DESCRIPTION
Master branch is no longer used by llvm-project