### PR TITLE
[MCDisassembler] Disambiguate Size parameter in tryAddingSymbolicOper…

### DIFF
--- a/X86/X86RaisedValueTracker.cpp
+++ b/X86/X86RaisedValueTracker.cpp
@@ -1344,7 +1344,7 @@ X86RaisedValueTracker::setInstMetadataRODataContent(LoadInst *LdInst) {
         // function is expected to do so.
         NewLdInst = new LoadInst(LdPtrTy->getPointerElementType(), ModSrcValue,
                                  "rodata-reloc", LdInst->isVolatile(),
-                                 Align(LdInst->getAlignment()));
+                                 Align(LdInst->getAlign()));
         // Copy metadata of the new load instruction to indicate that the loaded
         // value is content of rodata by propagating the metadata from
         // SrcValueAsInst.


### PR DESCRIPTION
…and()

MCSymbolizer::tryAddingSymbolicOperand() overloaded the Size parameter
to specify either the instruction size or the operand size depending on
the architecture. However, for proper symbolic disassembly on X86, we
need to know both sizes, as an instruction can have two operands, and
the instruction size cannot be reliably calculated based on the operand
offset and its size. Hence, split Size into OpSize and InstSize.

For X86, the new interface allows to fix a couple of issues:
  * Correctly adjust the value of PC-relative operands.
  * Set operand size to zero when the operand is specified implicitly.

https://github.com/llvm/llvm-project/commit/bed9efed71b954047aa11d5ed02af433dd9971cf