### PR TITLE
Rename function vars for global clang-tidy checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,9 +3,9 @@ Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: false
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true
@@ -27,7 +27,7 @@ BinPackParameters: true
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      false
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   false
   AfterNamespace:  false
@@ -105,7 +105,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false

--- a/ARM/ARMArgumentRaiser.cpp
+++ b/ARM/ARMArgumentRaiser.cpp
@@ -29,8 +29,8 @@ ARMArgumentRaiser::ARMArgumentRaiser(ARMModuleRaiser &mr)
 
 ARMArgumentRaiser::~ARMArgumentRaiser() {}
 
-void ARMArgumentRaiser::init(MachineFunction *mf, Function *rf) {
-  ARMRaiserBase::init(mf, rf);
+void ARMArgumentRaiser::init(MachineFunction *NewMF, Function *NewRF) {
+  ARMRaiserBase::init(NewMF, NewRF);
   MFI = &MF->getFrameInfo();
   TII = MF->getSubtarget<ARMSubtarget>().getInstrInfo();
 }

--- a/ARM/ARMArgumentRaiser.h
+++ b/ARM/ARMArgumentRaiser.h
@@ -29,23 +29,23 @@ class ARMArgumentRaiser : public ARMRaiserBase {
 public:
   static char ID;
 
-  ARMArgumentRaiser(ARMModuleRaiser &mr);
+  ARMArgumentRaiser(ARMModuleRaiser &MR);
   ~ARMArgumentRaiser() override;
-  void init(MachineFunction *mf = nullptr, Function *rf = nullptr) override;
+  void init(MachineFunction *MF = nullptr, Function *RF = nullptr) override;
   bool raiseArgs();
-  bool runOnMachineFunction(MachineFunction &mf) override;
+  bool runOnMachineFunction(MachineFunction &MF) override;
 
 private:
   /// Change all return relative register operands to stack 0.
-  void updateReturnRegister(MachineFunction &mf);
+  void updateReturnRegister(MachineFunction &MF);
   /// Change all function arguments of registers into stack elements with
   /// same indexes of arguments.
-  void updateParameterRegister(unsigned reg, MachineBasicBlock &mbb);
+  void updateParameterRegister(unsigned Reg, MachineBasicBlock &MBB);
   /// Change rest of function arguments on stack frame into stack elements.
-  void updateParameterFrame(MachineFunction &mf);
+  void updateParameterFrame(MachineFunction &MF);
   /// Using newly created stack elements replace relative operands in
   /// MachineInstr.
-  void updateParameterInstr(MachineFunction &mf);
+  void updateParameterInstr(MachineFunction &MF);
   /// Move arguments which are passed by ARM registers(R0 - R3) from function
   /// arg.x to corresponding registers in entry block.
   void moveArgumentToRegister(unsigned Reg, MachineBasicBlock &PMBB);

--- a/ARM/ARMInstructionSplitting.h
+++ b/ARM/ARMInstructionSplitting.h
@@ -28,9 +28,9 @@ namespace mctoll {
 class ARMInstructionSplitting : public ARMRaiserBase {
 public:
   static char ID;
-  ARMInstructionSplitting(ARMModuleRaiser &mr);
+  ARMInstructionSplitting(ARMModuleRaiser &MR);
   ~ARMInstructionSplitting() override;
-  void init(MachineFunction *mf = nullptr, Function *rf = nullptr) override;
+  void init(MachineFunction *MF = nullptr, Function *RF = nullptr) override;
   bool split();
   bool runOnMachineFunction(MachineFunction &mf) override;
 
@@ -44,21 +44,21 @@ private:
   MachineInstr *splitLDRSTRPreImm(MachineBasicBlock &MBB, MachineInstr &MI);
   MachineInstr *splitLDRSTRImm(MachineBasicBlock &MBB, MachineInstr &MI);
   MachineInstr *splitCommon(MachineBasicBlock &MBB, MachineInstr &MI,
-                            unsigned newOpc);
+                            unsigned NewOpc);
   MachineInstr *splitS(MachineBasicBlock &MBB, MachineInstr &MI,
-                       unsigned newOpc, int idx);
+                       unsigned NewOpc, int Idx);
   MachineInstr *splitC(MachineBasicBlock &MBB, MachineInstr &MI,
-                       unsigned newOpc, int idx);
+                       unsigned NewOpc, int Idx);
   MachineInstr *splitCS(MachineBasicBlock &MBB, MachineInstr &MI,
-                        unsigned newOpc, int idx);
+                        unsigned NewOpc, int Idx);
   /// True if the ARM instruction performs Shift_C().
-  bool isShift_C(unsigned Opcode);
+  bool isShift_C(unsigned Opcode); // NOLINT(readability-identifier-naming)
   /// No matter what pattern of Load/Store is, change the Opcode to xxxi12.
   unsigned getLoadStoreOpcode(unsigned Opcode);
   /// If the MI is load/store which needs wback, it will return true.
   bool isLDRSTRPre(unsigned Opcode);
-  MachineInstrBuilder &addOperand(MachineInstrBuilder &mib, MachineOperand &mo,
-                                  bool isDef = false);
+  MachineInstrBuilder &addOperand(MachineInstrBuilder &MIB, MachineOperand &MO,
+                                  bool IsDef = false);
 
   MachineRegisterInfo *MRI;
   const ARMBaseInstrInfo *TII;

--- a/ARM/ARMMIRevising.cpp
+++ b/ARM/ARMMIRevising.cpp
@@ -321,12 +321,12 @@ const Value *ARMMIRevising::getGlobalValueByOffset(int64_t MCInstOffset,
 
         auto SymOrErr = Symbol->getValue();
         if (!SymOrErr)
-          report_error(SymOrErr.takeError(), "Can not find the symbol!");
+          reportError(SymOrErr.takeError(), "Can not find the symbol!");
 
         uint64_t SymVirtAddr = *SymOrErr;
         auto SecOrErr = Symbol->getSection();
         if (!SecOrErr)
-          report_error(SecOrErr.takeError(),
+          reportError(SecOrErr.takeError(),
                        "Can not find the section which is the symbol in!");
 
         section_iterator SecIter = *SecOrErr;
@@ -340,7 +340,7 @@ const Value *ARMMIRevising::getGlobalValueByOffset(int64_t MCInstOffset,
         } else {
           auto StrOrErr = SecIter->getContents();
           if (!StrOrErr)
-            report_error(StrOrErr.takeError(),
+            reportError(StrOrErr.takeError(),
                          "Failed to get the content of section!");
           StringRef SecData = *StrOrErr;
           // Currently, Symbol->getValue() is virtual address.

--- a/ARM/ARMMachineInstructionRaiser.cpp
+++ b/ARM/ARMMachineInstructionRaiser.cpp
@@ -36,34 +36,34 @@ bool ARMMachineInstructionRaiser::raiseMachineFunction() {
   ARMModuleRaiser &rmr = const_cast<ARMModuleRaiser &>(*amr);
 
   ARMMIRevising mir(rmr);
-  mir.init(&MF, raisedFunction);
-  mir.setMCInstRaiser(mcInstRaiser);
+  mir.init(&MF, RaisedFunction);
+  mir.setMCInstRaiser(InstRaiser);
   mir.revise();
 
   ARMEliminatePrologEpilog epe(rmr);
-  epe.init(&MF, raisedFunction);
+  epe.init(&MF, RaisedFunction);
   epe.eliminate();
 
   ARMCreateJumpTable cjt(rmr);
-  cjt.init(&MF, raisedFunction);
-  cjt.setMCInstRaiser(mcInstRaiser);
+  cjt.init(&MF, RaisedFunction);
+  cjt.setMCInstRaiser(InstRaiser);
   cjt.create();
   cjt.getJTlist(jtList);
 
   ARMArgumentRaiser ar(rmr);
-  ar.init(&MF, raisedFunction);
+  ar.init(&MF, RaisedFunction);
   ar.raiseArgs();
 
   ARMFrameBuilder fb(rmr);
-  fb.init(&MF, raisedFunction);
+  fb.init(&MF, RaisedFunction);
   fb.build();
 
   ARMInstructionSplitting ispl(rmr);
-  ispl.init(&MF, raisedFunction);
+  ispl.init(&MF, RaisedFunction);
   ispl.split();
 
   ARMSelectionDAGISel sdis(rmr);
-  sdis.init(&MF, raisedFunction);
+  sdis.init(&MF, RaisedFunction);
   sdis.setjtList(jtList);
   sdis.doSelection();
 
@@ -98,14 +98,14 @@ Value *ARMMachineInstructionRaiser::getRegOrArgValue(unsigned PReg, int MBBNo) {
 
 FunctionType *ARMMachineInstructionRaiser::getRaisedFunctionPrototype() {
   ARMFunctionPrototype AFP;
-  raisedFunction = AFP.discover(MF);
+  RaisedFunction = AFP.discover(MF);
 
   Function *ori = const_cast<Function *>(&MF.getFunction());
   // Insert the map of raised function to tempFunctionPointer.
   const_cast<ModuleRaiser *>(MR)->insertPlaceholderRaisedFunctionMap(
-      raisedFunction, ori);
+      RaisedFunction, ori);
 
-  return raisedFunction->getFunctionType();
+  return RaisedFunction->getFunctionType();
 }
 
 // Create a new MachineFunctionRaiser object and add it to the list of

--- a/ARM/ARMRaiserBase.h
+++ b/ARM/ARMRaiserBase.h
@@ -26,18 +26,21 @@ namespace mctoll {
 class ARMRaiserBase : public FunctionPass {
 protected:
   ARMRaiserBase() = delete;
-  ARMRaiserBase(char &PassID, ARMModuleRaiser &mr)
-      : FunctionPass(PassID), MR(&mr) {
+  ARMRaiserBase(char &PassID, ARMModuleRaiser &ArmMR)
+      : FunctionPass(PassID), MR(&ArmMR) {
     M = MR->getModule();
   }
   ~ARMRaiserBase() override {}
-  virtual void init(MachineFunction *mf = nullptr, Function *rf = nullptr) {
-    if (mf)
-      MF = mf;
-    if (rf)
-      RF = rf;
+
+  virtual void init(MachineFunction *NewMF = nullptr, Function *NewRF = nullptr) {
+    if (NewMF)
+      MF = NewMF;
+    if (NewRF)
+      RF = NewRF;
   }
-  virtual bool runOnMachineFunction(MachineFunction &mf) { return false; }
+
+  virtual bool runOnMachineFunction(MachineFunction &CurrMF) { return false; }
+
   bool runOnFunction(Function &Func) override {
     RF = &Func;
     MF = MR->getMachineFunction(&Func);

--- a/ARM/DAG/DAGRaisingInfo.h
+++ b/ARM/DAG/DAGRaisingInfo.h
@@ -21,7 +21,7 @@
 namespace llvm {
 namespace mctoll {
 
-/// This is a extention of SelectionDAG. It contains additional information
+/// This is a extension of SelectionDAG. It contains additional information
 /// of DAG which is used by llvm-mctoll.
 class DAGRaisingInfo {
 public:

--- a/ARM/DAG/IREmitter.cpp
+++ b/ARM/DAG/IREmitter.cpp
@@ -699,7 +699,7 @@ void IREmitter::emitSpecialNode(SDNode *Node) {
                                // variadic function prototype.
     bool IsSyscall = false;
     if (CallFunc == nullptr) {
-      // According MI to get BL instruction address.
+      // According to MI to get BL instruction address.
       // uint64_t callAddr = DAGInfo->NPMap[Node]->InstAddr;
       uint64_t CallAddr = MR->getTextSectionAddress() +
                           getMCInstIndex(*(DAGInfo->NPMap[Node]->MI));

--- a/COFFDump.cpp
+++ b/COFFDump.cpp
@@ -304,7 +304,7 @@ static void printTLSDirectory(const COFFObjectFile *Obj) {
 
   const data_directory *DataDir = Obj->getDataDirectory(COFF::TLS_TABLE);
   if (!DataDir)
-    report_error("missing data dir for TLS table", Obj->getFileName());
+    reportError("missing data dir for TLS table", Obj->getFileName());
 
   uintptr_t IntPtr = 0;
   if (DataDir->RelativeVirtualAddress == 0)
@@ -334,7 +334,7 @@ static void printLoadConfiguration(const COFFObjectFile *Obj) {
   const data_directory *DataDir =
       Obj->getDataDirectory(COFF::LOAD_CONFIG_TABLE);
   if (!DataDir)
-    report_error("missing data dir for TLS table", Obj->getFileName());
+    reportError("missing data dir for TLS table", Obj->getFileName());
 
   uintptr_t IntPtr = 0;
   if (DataDir->RelativeVirtualAddress == 0)
@@ -675,11 +675,11 @@ void mctoll::printCOFFSymbolTable(const COFFObjectFile *coff) {
   for (unsigned SI = 0, SE = coff->getNumberOfSymbols(); SI != SE; ++SI) {
     auto Symbol = coff->getSymbol(SI);
     if (!Symbol)
-      report_error(Symbol.takeError(), coff->getFileName());
+      reportError(Symbol.takeError(), coff->getFileName());
 
     auto NameOrErr = coff->getSymbolName(*Symbol);
     if (!NameOrErr)
-      report_error(NameOrErr.takeError(), coff->getFileName());
+      reportError(NameOrErr.takeError(), coff->getFileName());
     StringRef Name = *NameOrErr;
 
     outs() << "[" << format("%2d", SI) << "]"

--- a/Raiser/FunctionFilter.cpp
+++ b/Raiser/FunctionFilter.cpp
@@ -23,12 +23,12 @@ using namespace llvm::mctoll;
 
 FunctionFilter::~FunctionFilter() {
   if (!ExcludedFunctionVector.empty())
-    for (auto FIE : ExcludedFunctionVector)
+    for (auto *FIE : ExcludedFunctionVector)
       if (FIE != nullptr)
         delete FIE;
 
   if (!IncludedFunctionVector.empty())
-    for (auto FII : IncludedFunctionVector)
+    for (auto *FII : IncludedFunctionVector)
       if (FII != nullptr)
         delete FII;
 }
@@ -206,7 +206,7 @@ FunctionFilter::findFuncInfoBySymbol(StringRef &Sym,
   else
     assert(false && "Unsupported filter type specified");
 
-  for (auto F : FunctionVec) {
+  for (auto *F : FunctionVec) {
     if (F->getSymName() == Sym)
       return F;
   }
@@ -227,7 +227,7 @@ Function *FunctionFilter::findFunctionByIndex(uint64_t StartIndex,
 
   assert(FuncVec != nullptr && "Unexpected null function vector");
 
-  for (auto F : *FuncVec) {
+  for (auto *F : *FuncVec) {
     if (F->StartIdx == StartIndex)
       return F->Func;
   }
@@ -251,7 +251,7 @@ void FunctionFilter::eraseFunctionBySymbol(StringRef &Sym,
   for (FunctionFilter::FuncInfoVector::iterator I = FuncVec->begin(),
                                                 E = FuncVec->end();
        I != E; ++I) {
-    auto EM = *I;
+    auto *EM = *I;
     if (EM != nullptr && EM->getSymName() == Sym) {
       FuncVec->erase(I);
       delete EM;
@@ -268,9 +268,9 @@ bool FunctionFilter::readFilterFunctionConfigFile(
   if (FunctionFilterFilename.size() == 0)
     return false;
 
-  std::ifstream f;
-  f.open(FunctionFilterFilename);
-  if (!f.is_open()) {
+  std::ifstream F;
+  F.open(FunctionFilterFilename);
+  if (!F.is_open()) {
     dbgs() << "Warning: Can not read the configuration file of filter "
               "function set!!!";
     return false;
@@ -278,8 +278,8 @@ bool FunctionFilter::readFilterFunctionConfigFile(
 
   FunctionFilter::FilterType FFType = FunctionFilter::FILTER_NONE;
   char Buf[512];
-  while (!f.eof()) {
-    f.getline(Buf, 512);
+  while (!F.eof()) {
+    F.getline(Buf, 512);
     StringRef RawLine(Buf);
     StringRef Line = RawLine.trim();
     // Ignore comment line
@@ -327,7 +327,7 @@ bool FunctionFilter::readFilterFunctionConfigFile(
     }
   }
   // Close function filter configuration file
-  f.close();
+  F.close();
   return true;
 }
 
@@ -336,7 +336,7 @@ bool FunctionFilter::isFilterSetEmpty(FilterType FT) {
   FuncInfoVector FunctionSet;
   if (FT == FILTER_INCLUDE)
     return IncludedFunctionVector.empty();
-  else if (FT == FILTER_EXCLUDE)
+  if (FT == FILTER_EXCLUDE)
     return ExcludedFunctionVector.empty();
 
   llvm_unreachable_internal("Unexpected function filter type specified");

--- a/Raiser/IncludedFileInfo.h
+++ b/Raiser/IncludedFileInfo.h
@@ -26,11 +26,11 @@ class IncludedFileInfo {
   ~IncludedFileInfo(){};
 
 public:
-  typedef struct FunctionRetAndArgs_t {
+  struct FunctionRetAndArgs {
     std::string ReturnType;
     std::vector<std::string> Arguments;
-    bool isVariadic;
-  } FunctionRetAndArgs;
+    bool IsVariadic;
+  };
 
   static Function *CreateFunction(StringRef &CFuncName, ModuleRaiser &MR);
 
@@ -43,7 +43,7 @@ public:
                                            std::string &Target,
                                            std::string &SysRoot);
 
-  static bool IsExternalVariable(std::string Name);
+  static bool isExternalVariable(std::string Name);
 };
 
 } // end namespace mctoll

--- a/Raiser/MCInstOrData.h
+++ b/Raiser/MCInstOrData.h
@@ -43,4 +43,4 @@ public:
 } // end namespace mctoll
 } // end namespace llvm
 
-#endif // LLVM_TOOLS_LLVM_MCTOLL_MCINSTRAISER_H
+#endif // LLVM_TOOLS_LLVM_MCTOLL_MCINSTORDATA_H

--- a/Raiser/MCInstRaiser.h
+++ b/Raiser/MCInstRaiser.h
@@ -27,25 +27,25 @@ public:
   using const_mcinst_iter = std::map<uint64_t, MCInstOrData>::const_iterator;
 
   MCInstRaiser(uint64_t Start, uint64_t End)
-      : FuncStart(Start), FuncEnd(End), dataInCode(false){};
+      : FuncStart(Start), FuncEnd(End), DataInCode(false){};
 
-  void addTarget(uint64_t targetIndex) {
+  void addTarget(uint64_t TargetIndex) {
     // Add targetIndex only if it falls within the function start and end
-    if (!((targetIndex >= FuncStart) && (targetIndex <= FuncEnd)))
+    if (!((TargetIndex >= FuncStart) && (TargetIndex <= FuncEnd)))
       return;
-    targetIndices.insert(targetIndex);
+    TargetIndices.insert(TargetIndex);
   }
 
-  void addMCInstOrData(uint64_t index, MCInstOrData mcInst);
+  void addMCInstOrData(uint64_t Index, MCInstOrData MCInst);
 
-  void buildCFG(MachineFunction &MF, const MCInstrAnalysis *mia,
-                const MCInstrInfo *mii);
+  void buildCFG(MachineFunction &MF, const MCInstrAnalysis *MIA,
+                const MCInstrInfo *MII);
 
-  std::set<uint64_t> getTargetIndices() const { return targetIndices; }
+  std::set<uint64_t> getTargetIndices() const { return TargetIndices; }
   uint64_t getFuncStart() const { return FuncStart; }
   uint64_t getFuncEnd() const { return FuncEnd; }
   // Change the value of function end to a new value greater than current value
-  bool adjustFuncEnd(uint64_t n);
+  bool adjustFuncEnd(uint64_t N);
   // Is Index in range of this function?
   bool isMCInstInRange(uint64_t Index) {
     return ((Index >= FuncStart) && (Index <= FuncEnd));
@@ -53,8 +53,8 @@ public:
   // Dump routine
   void dump() const;
   // Data in Code
-  void setDataInCode(bool v) { dataInCode = v; }
-  bool hasDataInCode() { return dataInCode; }
+  void setDataInCode(bool V) { DataInCode = V; }
+  bool hasDataInCode() { return DataInCode; }
 
   // Get the MBB number that corresponds to MCInst at Offset.
   // MBB has the raised MachineInstr corresponding to MCInst at
@@ -72,11 +72,11 @@ public:
   // Returns the iterator pointing to MCInstOrData at Offset in
   // input instruction stream.
   const_mcinst_iter getMCInstAt(uint64_t Offset) const {
-    return mcInstMap.find(Offset);
+    return InstMap.find(Offset);
   }
 
-  const_mcinst_iter const_mcinstr_begin() const { return mcInstMap.begin(); }
-  const_mcinst_iter const_mcinstr_end() const { return mcInstMap.end(); }
+  const_mcinst_iter const_mcinstr_begin() const { return InstMap.begin(); }
+  const_mcinst_iter const_mcinstr_end() const { return InstMap.end(); }
 
   // Get the size of instruction
   uint64_t getMCInstSize(uint64_t Offset) const;
@@ -88,19 +88,19 @@ private:
   //       targets. Separate data structures are used instead of aggregating the
   //       target information to minimize the amount of memory allocated
   //       per instruction - given the ratio of control flow instructions is
-  //       not high, in general. However it is important to populate the target
+  //       not high, in general. However, it is important to populate the target
   //       information during binary parse time AND is not duplicated.
   // A sequential list of source MCInsts or 32-bit data with corresponding index
   // Iteration over std::map contents is in non-descending order of keys. So,
   // the order in the map is guaranteed to be the order of instructions in the
   // insertion order i.e., code stream order.
-  std::map<uint64_t, MCInstOrData> mcInstMap;
+  std::map<uint64_t, MCInstOrData> InstMap;
   // All targets recorded in a set to avoid duplicate entries
-  std::set<uint64_t> targetIndices;
+  std::set<uint64_t> TargetIndices;
   // A map of MCInst index, mci, to MachineBasicBlock number, mbbnum. The first
   // instruction of MachineBasicBlock number mbbnum is the MachineInstr
   // representation of the MCinst at the index, mci
-  std::map<uint64_t, uint64_t> mcInstToMBBNum;
+  std::map<uint64_t, uint64_t> InstToMBBNum;
 
   std::map<uint64_t, std::vector<uint64_t>> MBBNumToMCInstTargetsMap;
   MachineInstr *RaiseMCInst(const MCInstrInfo &, MachineFunction &, MCInst,
@@ -111,7 +111,7 @@ private:
   // Flag to indicate that the mcInstVector includes data (or uint32_ sized
   // quantities that the disassembler was unable to recognize as instructions
   // and are considered data
-  bool dataInCode;
+  bool DataInCode;
 };
 
 } // end namespace mctoll

--- a/Raiser/MachineFunctionRaiser.cpp
+++ b/Raiser/MachineFunctionRaiser.cpp
@@ -14,8 +14,8 @@ using namespace llvm::mctoll;
 bool MachineFunctionRaiser::runRaiserPasses() {
   bool Success = false;
   // Raise MCInst to MachineInstr and Build CFG
-  if (machineInstRaiser != nullptr)
-    Success = machineInstRaiser->raise();
+  if (MachineInstRaiser != nullptr)
+    Success = MachineInstRaiser->raise();
 
   cleanupRaisedFunction();
   return Success;
@@ -34,13 +34,13 @@ void MachineFunctionRaiser::cleanupRaisedFunction() {
 }
 
 MachineInstructionRaiser *MachineFunctionRaiser::getMachineInstrRaiser() {
-  return machineInstRaiser;
+  return MachineInstRaiser;
 }
 
 Function *MachineFunctionRaiser::getRaisedFunction() {
-  return machineInstRaiser->getRaisedFunction();
+  return MachineInstRaiser->getRaisedFunction();
 }
 
 void MachineFunctionRaiser::setRaisedFunction(Function *F) {
-  return machineInstRaiser->setRaisedFunction(F);
+  return MachineInstRaiser->setRaisedFunction(F);
 }

--- a/Raiser/MachineFunctionRaiser.h
+++ b/Raiser/MachineFunctionRaiser.h
@@ -29,31 +29,31 @@ using IndexedData32 = std::pair<uint64_t, uint32_t>;
 
 class MachineFunctionRaiser {
 public:
-  MachineFunctionRaiser(Module &M, MachineFunction &MF, const ModuleRaiser *MR,
+  MachineFunctionRaiser(Module &TheM, MachineFunction &TheMF, const ModuleRaiser *TheMR,
                         uint64_t Start, uint64_t End)
-      : MF(MF), M(M), machineInstRaiser(nullptr), MR(MR) {
+      : MF(TheMF), M(TheM), MachineInstRaiser(nullptr), MR(TheMR) {
 
-    mcInstRaiser = new MCInstRaiser(Start, End);
+    InstRaiser = new MCInstRaiser(Start, End);
 
     // The new MachineFunction is not in SSA form, yet
     MF.getProperties().reset(MachineFunctionProperties::Property::IsSSA);
   };
 
-  virtual ~MachineFunctionRaiser() { delete mcInstRaiser; }
+  virtual ~MachineFunctionRaiser() { delete InstRaiser; }
 
   bool runRaiserPasses();
 
   MachineFunction &getMachineFunction() const { return MF; }
 
   // Getters
-  MCInstRaiser *getMCInstRaiser() { return mcInstRaiser; }
+  MCInstRaiser *getMCInstRaiser() { return InstRaiser; }
 
   Module &getModule() { return M; }
 
   MachineInstructionRaiser *getMachineInstrRaiser();
 
   void setMachineInstrRaiser(MachineInstructionRaiser *MIR) {
-    machineInstRaiser = MIR;
+    MachineInstRaiser = MIR;
   }
 
   Function *getRaisedFunction();
@@ -69,13 +69,13 @@ private:
   Module &M;
 
   // Data members built and used by this class
-  MCInstRaiser *mcInstRaiser;
-  MachineInstructionRaiser *machineInstRaiser;
+  MCInstRaiser *InstRaiser;
+  MachineInstructionRaiser *MachineInstRaiser;
   // A vector of data blobs found in the instruction stream
   // of this function. A data blob is a sequence of data bytes.
   // Multiple such data blobs may be found while disassembling
   // the instruction stream of a function symbol.
-  std::vector<IndexedData32> dataBlobVector;
+  std::vector<IndexedData32> DataBlobVector;
   const ModuleRaiser *MR;
 };
 

--- a/Raiser/MachineInstructionRaiser.h
+++ b/Raiser/MachineInstructionRaiser.h
@@ -26,7 +26,7 @@ namespace mctoll {
 // transfer (i.e., branch) instructions during a post-processing
 // phase.
 
-typedef struct ControlTransferInfo_t {
+struct ControlTransferInfo {
   BasicBlock *CandidateBlock;
   // This is the MachineInstr that needs to be raised
   const MachineInstr *CandidateMachineInstr;
@@ -39,14 +39,14 @@ typedef struct ControlTransferInfo_t {
   std::vector<Value *> RegValues;
   // Flag to indicate that CandidateMachineInstr has been raised
   bool Raised;
-} ControlTransferInfo;
+};
 
 class MachineInstructionRaiser {
 public:
   MachineInstructionRaiser() = delete;
-  MachineInstructionRaiser(MachineFunction &machFunc, const ModuleRaiser *mr,
-                           MCInstRaiser *mcir = nullptr)
-      : MF(machFunc), raisedFunction(nullptr), mcInstRaiser(mcir), MR(mr) {}
+  MachineInstructionRaiser(MachineFunction &TheMF, const ModuleRaiser *TheMR,
+                           MCInstRaiser *TheMCIR = nullptr)
+      : MF(TheMF), RaisedFunction(nullptr), InstRaiser(TheMCIR), MR(TheMR) {}
   virtual ~MachineInstructionRaiser(){};
 
   virtual bool raise() { return true; };
@@ -56,9 +56,9 @@ public:
   virtual bool buildFuncArgTypeVector(const std::set<MCPhysReg> &,
                                       std::vector<Type *> &) = 0;
 
-  Function *getRaisedFunction() { return raisedFunction; }
-  void setRaisedFunction(Function *F) { raisedFunction = F; }
-  MCInstRaiser *getMCInstRaiser() { return mcInstRaiser; }
+  Function *getRaisedFunction() { return RaisedFunction; }
+  void setRaisedFunction(Function *F) { RaisedFunction = F; }
+  MCInstRaiser *getMCInstRaiser() { return InstRaiser; }
   MachineFunction &getMF() { return MF; };
   const ModuleRaiser *getModuleRaiser() { return MR; }
 
@@ -71,8 +71,8 @@ protected:
   // This is the Function object that holds the raised abstraction of MF.
   // Note that the function associated with MF should not be referenced or
   // updated. It was created just to enable the creation of MF.
-  Function *raisedFunction;
-  MCInstRaiser *mcInstRaiser;
+  Function *RaisedFunction;
+  MCInstRaiser *InstRaiser;
   const ModuleRaiser *MR;
 
   // A vector of information to be used for raising of control transfer

--- a/Raiser/ModuleRaiser.h
+++ b/Raiser/ModuleRaiser.h
@@ -168,22 +168,22 @@ protected:
   bool InfoSet;
 };
 
-bool isSupportedArch(Triple::ArchType arch);
-ModuleRaiser *getModuleRaiser(const TargetMachine *tm);
-void registerModuleRaiser(ModuleRaiser *m);
+bool isSupportedArch(Triple::ArchType Arch);
+ModuleRaiser *getModuleRaiser(const TargetMachine *TM);
+void registerModuleRaiser(ModuleRaiser *M);
 
 // error functions used from main and from raisers libs
 extern StringRef ToolName;
 
-void error(std::error_code ec);
+void error(std::error_code EC);
 void error(Error E);
 [[noreturn]] void error(Twine Message);
-[[noreturn]] void report_error(StringRef File, Twine Message);
-[[noreturn]] void report_error(Error E, StringRef File);
-[[noreturn]] void report_error(Error E, StringRef FileName,
+[[noreturn]] void reportError(StringRef File, Twine Message);
+[[noreturn]] void reportError(Error E, StringRef File);
+[[noreturn]] void reportError(Error E, StringRef FileName,
                                StringRef ArchiveName,
                                StringRef ArchitectureName = StringRef());
-[[noreturn]] void report_error(Error E, StringRef ArchiveName,
+[[noreturn]] void reportError(Error E, StringRef ArchiveName,
                                const object::Archive::Child &C,
                                StringRef ArchitectureName = StringRef());
 
@@ -191,7 +191,7 @@ template <typename T, typename... Ts>
 T unwrapOrError(Expected<T> EO, Ts &&...Args) {
   if (EO)
     return std::move(*EO);
-  report_error(EO.takeError(), std::forward<Ts>(Args)...);
+  reportError(EO.takeError(), std::forward<Ts>(Args)...);
 }
 
 } // end namespace mctoll

--- a/Raiser/RuntimeFunction.cpp
+++ b/Raiser/RuntimeFunction.cpp
@@ -29,30 +29,30 @@ Function *RuntimeFunction::getOrCreateSecOffsetCalcFunction(Module &M) {
     Type *Int64Ty = Type::getInt64Ty(Ctx);
     Value *Zero64BitValue = ConstantInt::get(Int64Ty, 0, false /* isSigned */);
 
-    SmallVector<Type *, 4> argTypes = {
+    SmallVector<Type *, 4> ArgTypes = {
         Int64Ty /* RODAddr */,
         Int64Ty /* SecStAddr */,
         Int64Ty /*SecSize */,
         Int64Ty /* Runtime ROData GV */,
     };
-    ArrayRef<Type *> argTypeVector(argTypes);
+    ArrayRef<Type *> ArgTypeVector(ArgTypes);
 
     FunctionType *FuncType =
-        FunctionType::get(Int64Ty, argTypeVector, false /* isVarArg*/);
+        FunctionType::get(Int64Ty, ArgTypeVector, false /* isVarArg*/);
 
     // Create function
     Func =
         Function::Create(FuncType, GlobalValue::ExternalLinkage, FuncName, M);
     Func->setCallingConv(CallingConv::C);
 
-    Function::arg_iterator args = Func->arg_begin();
-    Value *InAddr = args++;
+    Function::arg_iterator Args = Func->arg_begin();
+    Value *InAddr = Args++;
     InAddr->setName("InAddr");
-    Value *SecBeg = args++;
+    Value *SecBeg = Args++;
     SecBeg->setName("SecBeg");
-    Value *SecSz = args++;
+    Value *SecSz = Args++;
     SecSz->setName("SecSz");
-    Value *RTGV = args++;
+    Value *RTGV = Args++;
     RTGV->setName("RTGV");
 
     // Create the entry basic block

--- a/X86/X86AdditionalInstrInfo.h
+++ b/X86/X86AdditionalInstrInfo.h
@@ -92,27 +92,27 @@ static inline uint8_t getInstructionBitPrecision(uint64_t TSFlags) {
   // Instructions using prefix to indicate precision
   if ((TSFlags & llvm::X86II::OpPrefixMask) == llvm::X86II::XS) {
     return 32;
-  } else if ((TSFlags & llvm::X86II::OpPrefixMask) == llvm::X86II::XD) {
+  }
+  if ((TSFlags & llvm::X86II::OpPrefixMask) == llvm::X86II::XD) {
     return 64;
-  } else {
-    // Instructions operating on packed values
-    auto Domain = (TSFlags >> llvm::X86II::SSEDomainShift) & 3;
-    // X64BaseInfo.h does not define enums. X86InstrFormats.td specified
-    // GenericDomain = 0 (non-SSE instruction)
-    // SSEPackedSingle = 1
-    // SSEPackedSouble = 2
-    // SSEPackedInt = 3
-    switch (Domain) {
-    case 1:
-    case 3:
-      return 32;
-    case 2:
-      return 64;
-    case 0:
-      return 0;
-    default:
-      llvm_unreachable("Unknown precision in instruction encoding");
-    }
+  }
+  // Instructions operating on packed values
+  auto Domain = (TSFlags >> llvm::X86II::SSEDomainShift) & 3;
+  // X64BaseInfo.h does not define enums. X86InstrFormats.td specified
+  // GenericDomain = 0 (non-SSE instruction)
+  // SSEPackedSingle = 1
+  // SSEPackedSouble = 2
+  // SSEPackedInt = 3
+  switch (Domain) {
+  case 1:
+  case 3:
+    return 32;
+  case 2:
+    return 64;
+  case 0:
+    return 0;
+  default:
+    llvm_unreachable("Unknown precision in instruction encoding");
   }
 }
 

--- a/X86/X86MachineInstructionRaiser.h
+++ b/X86/X86MachineInstructionRaiser.h
@@ -63,7 +63,7 @@ public:
   // Return type of the floating point physical register
   Type *getPhysSSERegType(unsigned int PhysReg, uint8_t BitPrecision);
 
-  bool insertAllocaInEntryBlock(Instruction *alloca, int StackOffset,
+  bool insertAllocaInEntryBlock(Instruction *Alloca, int StackOffset,
                                 int MFIndex);
   BasicBlock *getRaisedBasicBlock(const MachineBasicBlock *);
   bool recordDefsToPromote(unsigned PhysReg, unsigned MBBNo, Value *Alloca);
@@ -71,7 +71,7 @@ public:
                                        int MBBNo, Instruction *Alloca);
   int getArgumentNumber(unsigned PReg) override;
   auto getRegisterInfo() const { return x86RegisterInfo; }
-  bool instrNameStartsWith(const MachineInstr &MI, StringRef name) const;
+  bool instrNameStartsWith(const MachineInstr &MI, StringRef Name) const;
   X86RaisedValueTracker *getRaisedValues() { return raisedValues; }
 
 private:
@@ -176,14 +176,14 @@ private:
   // Raise Machine Jumptable
   bool raiseMachineJumpTable();
 
-  Value *getSwitchCompareValue(MachineBasicBlock &mbb);
+  Value *getSwitchCompareValue(MachineBasicBlock &MBB);
 
   // FPU Stack access functions
-  void FPURegisterStackPush(Value *);
-  void FPURegisterStackPop();
-  Value *FPURegisterStackGetValueAt(int8_t);
-  void FPURegisterStackSetValueAt(int8_t, Value *);
-  Value *FPURegisterStackTop();
+  void pushFPURegisterStack(Value *Val);
+  void popFPURegisterStack();
+  Value *getFPURegisterStackValueAt(int8_t);
+  void setFPURegisterStackValueAt(int8_t, Value *);
+  Value *topFPURegisterStack();
 
   int getMemoryRefOpIndex(const MachineInstr &);
   Value *getGlobalVariableValueAt(const MachineInstr &, uint64_t);
@@ -192,7 +192,7 @@ private:
   Value *getMemoryAddressExprValue(const MachineInstr &);
   Value *createPCRelativeAccesssValue(const MachineInstr &);
 
-  bool changePhysRegToVirtReg(MachineInstr &);
+  bool changePhysRegToVirtReg(MachineInstr &MI);
 
   Value *getPhysRegValue(const MachineInstr &, unsigned);
 
@@ -201,7 +201,7 @@ private:
   Type *getReturnTypeFromMBB(const MachineBasicBlock &MBB, bool &HasCall);
   Function *getTargetFunctionAtPLTOffset(const MachineInstr &, uint64_t);
   Value *getStackAllocatedValue(const MachineInstr &, X86AddressMode &, bool);
-  Value *getRegOperandValue(const MachineInstr &mi, unsigned OperandIndex);
+  Value *getRegOperandValue(const MachineInstr &MI, unsigned OperandIndex);
 
   bool handleUnpromotedReachingDefs();
   bool handleUnterminatedBlocks();
@@ -222,7 +222,7 @@ private:
   bool isPopFromStack(const MachineInstr &MI) const;
   bool isEffectiveAddrValue(Value *Val);
 
-  std::vector<JumpTableInfo> jtList;
+  std::vector<JumpTableInfo> JTList;
 };
 
 } // end namespace mctoll

--- a/X86/X86RaisedValueTracker.h
+++ b/X86/X86RaisedValueTracker.h
@@ -106,14 +106,14 @@ public:
   enum { INVALID_MBB = -1 };
 
 private:
-  X86MachineInstructionRaiser *x86MIRaiser;
+  X86MachineInstructionRaiser *X86MIRaiser;
   // Map of physical registers -> MBBNoToValueMap, representing per-block
   // register definitions.
-  PhysRegMBBValueDefMap physRegDefsInMBB;
+  PhysRegMBBValueDefMap PhysRegDefsInMBB;
 };
 
 
 } // end namespace mctoll
 } // end namespace llvm
 
-#endif // LVM_TOOLS_LLVM_MCTOLL_X86_X86RAISEDVALUETRACKER_H
+#endif // LLVM_TOOLS_LLVM_MCTOLL_X86_X86RAISEDVALUETRACKER_H

--- a/X86/X86RegisterUtils.cpp
+++ b/X86/X86RegisterUtils.cpp
@@ -50,12 +50,11 @@ bool X86RegisterUtils::isEflagBit(unsigned RegNo) {
 
 int X86RegisterUtils::getEflagBitIndex(unsigned EFBit) {
   assert(isEflagBit(EFBit) && "Undefined EFLAGS bit");
-  int index = 0;
-  for (auto v : X86RegisterUtils::EFlagBits) {
-    if (v == EFBit)
-      return index;
-    else
-      index++;
+  int Index = 0;
+  for (auto V : X86RegisterUtils::EFlagBits) {
+    if (V == EFBit)
+      return Index;
+    Index++;
   }
   assert(false && "Unknown EFLAGS bit");
   return -1;
@@ -114,13 +113,13 @@ bool X86RegisterUtils::is8BitPhysReg(unsigned int PReg) {
 unsigned int X86RegisterUtils::getPhysRegSizeInBits(unsigned int PReg) {
   if (X86RegisterUtils::is64BitPhysReg(PReg) || X86RegisterUtils::is64BitSSE2Reg(PReg))
     return 64;
-  else if (X86RegisterUtils::is32BitPhysReg(PReg) || X86RegisterUtils::is32BitSSE2Reg(PReg))
+  if (X86RegisterUtils::is32BitPhysReg(PReg) || X86RegisterUtils::is32BitSSE2Reg(PReg))
     return 32;
-  else if (X86RegisterUtils::is16BitPhysReg(PReg))
+  if (X86RegisterUtils::is16BitPhysReg(PReg))
     return 16;
-  else if (X86RegisterUtils::is8BitPhysReg(PReg))
+  if (X86RegisterUtils::is8BitPhysReg(PReg))
     return 8;
-  else if (isEflagBit(PReg))
+  if (isEflagBit(PReg))
     return 1;
 
   llvm_unreachable("Unhandled physical register specified");
@@ -141,11 +140,14 @@ unsigned X86RegisterUtils::getArgumentReg(int Index, Type *Ty) {
   // Note: any pointer is an address and hence uses a 64-bit register
   if ((Ty == Type::getInt64Ty(Ctx)) || (Ty->isPointerTy())) {
     return X86RegisterUtils::GPR64ArgRegs64Bit[Index];
-  } else if (Ty == Type::getInt32Ty(Ctx)) {
+  }
+  if (Ty == Type::getInt32Ty(Ctx)) {
     return X86RegisterUtils::GPR64ArgRegs32Bit[Index];
-  } else if (Ty == Type::getInt16Ty(Ctx)) {
+  }
+  if (Ty == Type::getInt16Ty(Ctx)) {
     return X86RegisterUtils::GPR64ArgRegs16Bit[Index];
-  } else if (Ty == Type::getInt8Ty(Ctx)) {
+  }
+  if (Ty == Type::getInt8Ty(Ctx)) {
     return X86RegisterUtils::GPR64ArgRegs8Bit[Index];
   }
   return 0;


### PR DESCRIPTION
Massive internal vars and function rename in the Raiser and X86 subsystem for satisfy global .clang-tidy configuration.