### PR TITLE
Fix CMakeLists.txt to allow building when LLVM backend is configured …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,7 @@ set(LLVM_LINK_COMPONENTS
   Option
   Support
   Symbolize
-  ARM
-  X86
+  ${LLVM_TARGETS_TO_BUILD}
   )
 
 add_subdirectory(Raiser)


### PR DESCRIPTION
…other than x86 and arm.

Although llvm-mctoll currently only support x86 and arm, it should be built correctly when the backend of llvm project is configured of architectures other than x86 and arm.

Due to the following codes in mctoll, the linker will report undefined symbol for the MC layer components of other machine arch.

```
  // Initialize targets and assembly printers/parsers.
  llvm::InitializeAllTargets();
  llvm::InitializeAllTargetInfos();
  llvm::InitializeAllTargetMCs();
  llvm::InitializeAllDisassemblers();

```

We can use `${LLVM_TARGETS_TO_BUILD}` in CMakeLists file to avoid the error, though it includes unnecessary components of other architectures.
